### PR TITLE
Problem: No way to test the library

### DIFF
--- a/Tests/Dummy.lean
+++ b/Tests/Dummy.lean
@@ -1,0 +1,8 @@
+import LSpec
+
+def twoTests : LSpec :=
+  it "knows equality" 42 (shouldBe 42) $
+  it "knows lists" [42].length (shouldBe 1)
+
+def main :=
+  lspec "some description" twoTests

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -6,6 +6,9 @@ package Megaparsec {
   dependencies := #[{
     name := "mathlib",
     src := Source.git "https://github.com/leanprover-community/mathlib4.git" "6895646674b04c0d7bcd085b4da3f7bb354ceaa9"
+  }, {
+    name := "LSpec",
+    src := Source.git "https://github.com/yatima-inc/LSpec.git" "f71c4dd98c5735599664100acfaaa5f6238d13a3"
   }],
   defaultFacet := PackageFacet.oleans -- no executable is generated
 }


### PR DESCRIPTION
Solution:

 - Add LSpec, figure out how to build it
 - Add Tests folder, as per LSpec README
 - Manually test that tests run and work:

```
Tue Jun 21 18:05:42:852290600 sweater@conflagrate ~/github/Megaparsec.lean (cognivore/test-api)
λ lake build LSpec && lean_packages/LSpec/build/bin/lspec
info: mathlib: trying to update ./lean_packages/mathlib to revision 6895646674b04c0d7bcd085b4da3f7bb354ceaa9
info: LSpec: trying to update ./lean_packages/LSpec to revision f71c4dd98c5735599664100acfaaa5f6238d13a3
Building main package

Running tests for Dummy.lean
Testing that: some description
✓ it knows equality
✓ it knows lists

All tests passed!
```