### PR TITLE
Printing parse errors!

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "lake build",
+      "type": "shell",
+      "command": "lake build",
+      "problemMatcher": [],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
+}

--- a/Main.lean
+++ b/Main.lean
@@ -59,7 +59,7 @@ def main : IO Unit := do
 ")
     let _eos ← (MonadParsec.eof S String)
     pure $ res1 ++ res2
-  IO.println "Let's see if @ixhaedron's test passes."
+  IO.println "Let's see if @ixahedron's test passes."
   let _ix : (Bool × Either Unit String) ← parseTestTP abcdpnl bh
   let h1 ← IO.FS.Handle.mk (System.mkFilePath ["./Tests", "abcd-no-nl.txt"]) IO.FS.Mode.read false
   let _ixx : (Bool × Either Unit String) ← parseTestTP (string Q S "abcd" <* MonadParsec.eof S String) ("", h1)

--- a/Megaparsec/Errors/StreamErrors.lean
+++ b/Megaparsec/Errors/StreamErrors.lean
@@ -51,6 +51,9 @@ def mergeErrors (e₁: ParseError β E)
           | (.fancy s₁ x₁, .fancy _ x₂) => .fancy s₁ (x₁ ++ x₂)
     | Ordering.gt => e₁
 
+instance : Append (ParseError β E) where
+  append := mergeErrors
+
 def toHints (streamPos : Nat) (e : ParseError α E) : Hints α :=
   match e with
     | ParseError.fancy _ _ => []

--- a/Megaparsec/Parsec.lean
+++ b/Megaparsec/Parsec.lean
@@ -6,6 +6,7 @@ import Megaparsec.Errors.StreamErrors
 -- import Megaparsec.Errors.StreamErrors
 import Megaparsec.Ok
 import Megaparsec.ParserState
+import Megaparsec.Streamable
 import Straume
 import Straume.Chunk
 import Straume.Coco
@@ -23,6 +24,7 @@ open Megaparsec.Errors
 -- open Megaparsec.Errors.StreamErrors
 open Megaparsec.Ok
 open Megaparsec.ParserState
+open Megaparsec.Streamable
 
 open Straume
 open Straume.Flood
@@ -168,7 +170,7 @@ def runParserT' {m : Type u → Type v} {β σ E γ : Type u}
     | .err e => (s₁, .left (toBundle s₀ $ List.toNEList e s₁.parseErrors))
 
 def parseTestTP {m : Type → Type v} {β σ E : Type} {γ : Type}
-                (p : ParsecT m β σ E γ) (xs : σ) (srcName := "(test run)") [ToString E] [ToString β] [ToString γ] [Monad m] [MonadLiftT m IO]
+                (p : ParsecT m β σ E γ) (xs : σ) (srcName := "(test run)") [ToString E] [ToString β] [ToString γ] [Monad m] [MonadLiftT m IO] [Streamable σ]
                 : IO (Bool × Either Unit γ) := do
   let reply ← liftM $ runParserT' p (initialState srcName xs)
   match reply.2 with
@@ -189,11 +191,10 @@ def parseP (p : Parsec β σ E γ) (srcName : String) (xs : σ) :=
   runParserP p srcName xs
 
 /- Test some parser polymorphically. -/
-def parseTestP (p : Parsec β σ E γ) (xs : σ) [ToString γ]
-               : IO (Bool × Either Unit γ) :=
+def parseTestP (p : Parsec β σ E γ) [ToString γ] [ToString β] [ToString E]
+  (xs : σ) [Streamable σ] : IO (Bool × Either Unit γ) :=
   match parseP p "" xs with
-  -- TODO: Learn to print errors!
-  | .left _e => IO.println "There were some errors." >>= fun _ => pure $ (false, Either.left ())
+  | .left es => IO.println s!"{es}" >>= fun _ => pure $ (false, Either.left ())
   | .right y => IO.println y >>= fun _ => pure $ (true, Either.right y)
 
 ---===========================================================--

--- a/Megaparsec/Pos.lean
+++ b/Megaparsec/Pos.lean
@@ -2,5 +2,20 @@ namespace Megaparsec.Pos
 
 structure Pos where
   pos : Nat
+  deriving Repr, DecidableEq
 
 export Pos (pos)
+
+instance : Add Pos where
+  add | ⟨x⟩, ⟨y⟩ => ⟨x + y⟩
+
+def pos1 : Pos := Pos.mk 1
+
+partial def expandTab (tw : Nat) (str : String) : String :=
+  let strl := str.data
+  let rec go : Nat → List Char → List Char
+    | 0, [] => []
+    | 0, ('\t' :: xs) => go tw xs
+    | 0, (x :: xs) => x :: go 0 xs
+    | n, xs => ' ' :: go (n - 1) xs
+  String.mk $ go 0 strl

--- a/Megaparsec/Streamable.lean
+++ b/Megaparsec/Streamable.lean
@@ -1,0 +1,143 @@
+import Megaparsec.ParserState
+import Megaparsec.Pos
+
+import Straume.Coco
+import Straume.Iterator
+import Straume.Zeptoparsec
+
+open Megaparsec.ParserState
+open Megaparsec.Pos
+
+open Straume.Coco
+open Straume.Iterator
+open Zeptoparsec
+
+namespace Megaparsec.Streamable
+
+class Streamable (σ : Type u) where
+/-
+  Given an offset `o` and initial `PosState`, adjust the state in such
+  a way that it starts at the offset.
+
+  Return two values (in order):
+
+      * `Option String` representing the line on which the given offset
+        `o` is located. It can be omitted (i.e. `.none`); in that case
+        error reporting functions will not show offending lines. If
+        returned, the line should satisfy a number of conditions that are
+        described below.
+      * The updated `PosState` which can be in turn used to locate
+        another offset `o'` given that `o' >= o`.
+
+  The `String` representing the offending line in input stream should
+  satisfy the following:
+
+      * It should adequately represent location of token at the offset of
+        interest, that is, character at `column` of the returned
+        `SourcePos` should correspond to the token at the offset @o@.
+      * It should not include the newline at the end.
+      * It should not be empty, if the line happens to be empty, it
+        should be replaced with the string `"<empty line>"`.
+      * Tab characters should be replaced by appropriate number of
+        spaces, which is determined by the `tabWidth` field of
+        `PosState`.
+-/
+  reachOffset (o : Nat) (pst : PosState σ) : (Option String × PosState σ)
+
+  -- A version of `reachOffset` that may be faster because it doesn't need
+  -- to fetch the line at which the given offset in located.
+  --
+  -- It's currently not possible to use `reachOffsetNoLine` as a minimal
+  -- definition; unlike Haskell, Lean4 doesn't(?) allow mutually
+  -- recursive class defs.
+  reachOffsetNoLine (o : Nat) (pst : PosState σ) : PosState σ
+    := (reachOffset o pst).2
+
+export Streamable (reachOffset reachOffsetNoLine)
+
+---===========================================================--
+---========================= HELPERS =========================--
+---===========================================================--
+
+-- A helper definition to facilitate defining `reachOffset` for various
+-- stream types.
+def reachOffset'
+  (fsplit : Nat → σ → (σ × σ)) -- How to split input stream at given offset
+  (ffold : ∀φ, (φ → β → φ) → φ → σ → φ) [Iterable σ β] [DecidableEq β] -- How to fold over input stream;
+  -- How to convert chunk of input stream into a `String`.
+  -- We only need it to handle adding `linePrefix`.
+  (fstr : σ → String)
+  (nlt : β) (tabt : β) -- Newline token and tab token
+  (o : Nat) -- Offset to reach
+  (pst : PosState σ) -- Initial `PosState` to use
+  [DecidableEq σ] [Inhabited σ] -- for Zeptoparsec
+  : (Option String × PosState σ) -- Line at which `SourcePos` is located, updated `PosState`
+  := let prepend c (str : σ) := fromList $ c :: (toList str)
+  let go | (apos, g), ch => if ch = nlt then
+      ({ apos with line := apos.line + pos1, column := pos1 }, id)
+    else if ch = tabt then
+      let c' := apos.column.pos
+      ({ apos with column :=
+        Pos.mk $ c' + pst.tabWidth - ((c' - 1) % pst.tabWidth)}
+      , (g ∘ prepend ch))
+    else ({ apos with column := apos.column + pos1}, (g ∘ prepend ch))
+  let (pre, post) := fsplit (o - pst.offset) pst.input
+  let (spos, f) :=
+    ffold (SourcePos × (σ → σ)) go (pst.sourcePos, id) pre
+  let isSameLine := spos.line = pst.sourcePos.line
+  let addPrefix xs := if isSameLine then pst.linePrefix ++ xs else xs
+
+  let taken? := (Zeptoparsec.run (manyChars (satisfy (fun c => c != nlt))) post).toOption
+  let location :=
+    match (expandTab pst.tabWidth ∘ addPrefix ∘ fstr ∘ f) <$> taken? with
+    | .none    => .none
+    | .some "" => .some "<empty line>"
+    | .some xs => .some xs
+  (location,
+  { input := post, offset := max pst.offset o, sourcePos := spos
+  , tabWidth := pst.tabWidth
+  , linePrefix :=
+      if isSameLine
+      then pst.linePrefix ++ fstr (f default)
+      else fstr $ f default
+  })
+
+def reachOffsetNoLine'
+  (fsplit : Nat → σ → (σ × σ)) -- How to split input stream at given offset
+  (ffold : ∀φ, (φ → β → φ) → φ → σ → φ) [Iterable σ β] [DecidableEq β] -- How to fold over input stream;
+  -- How to convert chunk of input stream into a `String`.
+  -- We only need it to handle adding `linePrefix`.
+  (nlt : β) (tabt : β) -- Newline token and tab token
+  (o : Nat) -- Offset to reach
+  (pst : PosState σ) -- Initial `PosState` to use
+  [DecidableEq σ] [Inhabited σ] -- for Zeptoparsec
+  : PosState σ := -- Updated `PosState`
+  let go | apos, ch => if ch = nlt
+    then { apos with line := apos.line + pos1, column := pos1 }
+    else if ch = tabt then
+      let c' := apos.column.pos
+      { apos with column :=
+        Pos.mk $ c' + pst.tabWidth - ((c' - 1) % pst.tabWidth) }
+    else { apos with column := apos.column + pos1 }
+  let (pre, post) := fsplit (o - pst.offset) pst.input
+  let spos := ffold SourcePos go pst.sourcePos pre
+
+  { pst with input := post, offset := max pst.offset o, sourcePos := spos }
+
+---===========================================================--
+---================== STREAMABLE INSTANCES ===================--
+---===========================================================--
+
+private def splitAt (n : Nat) (str : String) := (str.take n, str.drop n)
+
+instance : Streamable String where
+  reachOffset o pst := reachOffset' splitAt @String.foldl id '\n' '\t' o pst
+  reachOffsetNoLine o pst :=
+    reachOffsetNoLine' splitAt @String.foldl '\n' '\t' o pst
+
+instance [Streamable σ] [Coco σ (σ × η)] : Streamable (σ × η) where
+  reachOffset o pst :=
+    let inner : σ := Coco.coco pst.input
+    let (ol, npst) := reachOffset o $ { pst with input := inner }
+    (ol, { npst with input := Coco.replace pst.input npst.input })
+


### PR DESCRIPTION
Problem: parse errors, though they exist, are currently as good as useless.
We can't print them, we can't use them. We need to do better!

Solution: added a Streamable type class that allows us to change offsets there
and back again. Currently, it only implements String, as well as Coco-coersive
types. We need to at least add an instance for ByteArrays, and maybe more.
Actually added correct(ish) printing of errors!