### PR TITLE
Finish errors w/ pretty-printing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /build
 /lean_packages
+
+# Ignore nix stuff, just in case?
+/result

--- a/Megaparsec/Common.lean
+++ b/Megaparsec/Common.lean
@@ -32,35 +32,24 @@ def single (m : Type u → Type v) (℘ E α : Type u) (x : β) [MonadParsec m �
 def string (m : Type u → Type v) (℘ E β : Type u) {α : Type u} (x : α) [MonadParsec m ℘ α E β] [BEq α] : m α :=
   MonadParsec.tokens ℘ E β (BEq.beq) x
 
--- TODO: Move the following several fucntions to YatimaStdLib or even to Lean 4
-def between [SeqLeft φ] [SeqRight φ] (f : φ α) (h : φ β) (g : φ γ) : φ γ :=
-  f *> g <* h
-
-def liftSeq2 [Seq φ] [Functor φ] (f2 : α → β → γ) (x : φ α) : (Unit → φ β) → φ γ :=
-  Seq.seq (Functor.map f2 x)
-
-def void [Functor φ] (fx : φ a) : φ Unit :=
-  (fun _ => ()) <$> fx
-
-
 -- TODO: A lot of thunks here. Support monadic versions of these combinators.
 -- TODO: Why doesn't generic version work? https://zulip.yatima.io/#narrow/stream/10-lean/topic/_spec_10.20constant.3F/near/19689
 -- mutual
 --   partial def some [Alternative φ] [Inhabited (φ (List α))] (p : φ α) : φ (List α) :=
---     liftSeq2 List.cons p $ fun () => many p
+--     Seq.liftSeq2 List.cons p $ fun () => many p
 --   partial def many [Alternative φ] [Inhabited (φ (List α))] (p : φ α) : φ (List α) :=
 --     some p <|> pure []
 -- end
 -- partial def many1 [Alternative φ] [Inhabited (φ (List α))] : φ α → φ (List α) := some
 
 -- partial def sepBy1 [Alternative φ] [Inhabited (φ (List α))] (p : φ α) (sep : φ β) : φ (List α) :=
---   liftSeq2 List.cons p fun () => (many $ sep *> p)
+--   Seq.liftSeq2 List.cons p fun () => (many $ sep *> p)
 -- partial def sepBy [Alternative φ] [Inhabited (φ (List α))] (p : φ α) (sep : φ β) : φ (List α) :=
 --   sepBy1 p sep <|> pure []
 
 -- mutual
 --   partial def sepEndBy1 [Alternative φ] [Inhabited (φ (List α))] (p : φ α) (sep : φ β) : φ (List α) :=
---     liftSeq2 List.cons p fun () => ((sep *> sepEndBy p sep) <|> pure [])
+--     Seq.liftSeq2 List.cons p fun () => ((sep *> sepEndBy p sep) <|> pure [])
 --   partial def sepEndBy [Alternative φ] [Inhabited (φ (List α))] (p : φ α) (sep : φ β) : φ (List α) :=
 --     sepEndBy1 p sep <|> pure []
 -- end
@@ -94,7 +83,7 @@ partial def many1 (m : Type u → Type v) (σ α β E : Type u) {γ : Type u} (p
 
 -- mutual
 --   partial def sepEndBy1 [Alternative φ] [Inhabited (φ (List α))] (p : φ α) (sep : φ β) : φ (List α) :=
---     liftSeq2 List.cons p fun () => ((sep *> sepEndBy p sep) <|> pure [])
+--     Seq.liftSeq2 List.cons p fun () => ((sep *> sepEndBy p sep) <|> pure [])
 --   partial def sepEndBy [Alternative φ] [Inhabited (φ (List α))] (p : φ α) (sep : φ β) : φ (List α) :=
 --     sepEndBy1 p sep <|> pure []
 -- end

--- a/Megaparsec/Errors/Bundle.lean
+++ b/Megaparsec/Errors/Bundle.lean
@@ -1,5 +1,6 @@
 import Megaparsec.Errors.ParseError
 import Megaparsec.ParserState
+import Megaparsec.Printable
 import Megaparsec.Streamable
 import YatimaStdLib
 
@@ -7,6 +8,7 @@ namespace Megaparsec.Errors.Bundle
 
 open Megaparsec.Errors.ParseError
 open Megaparsec.ParserState
+open Megaparsec.Printable
 open Megaparsec.Streamable
 
 structure ParseErrorBundle (β σ E : Type u) where
@@ -14,7 +16,7 @@ structure ParseErrorBundle (β σ E : Type u) where
   posState : PosState σ
 
 -- Helper that makes necessary functions for the `ToString` instance.
-private def makePEBfs [ToString β] [ToString E] [Streamable σ] : ((String → String) × PosState σ) → ParseError β E → ((String → String) × PosState σ)
+private def makePEBfs [Printable β] [ToString E] [Streamable σ] : ((String → String) × PosState σ) → ParseError β E → ((String → String) × PosState σ)
   | (o, pst), e =>
     let (msline, pst') := Streamable.reachOffset (errorOffset e) pst
     let epos := pst'.sourcePos
@@ -47,7 +49,7 @@ private def makePEBfs [ToString β] [ToString E] [Streamable σ] : ((String → 
   lines by doing a single pass over the input stream. The rendered `String`
   always ends with a newline.
 -/
-instance [ToString β] [ToString E] [Streamable σ] : ToString (ParseErrorBundle β σ E) where
+instance [Printable β] [ToString E] [Streamable σ] : ToString (ParseErrorBundle β σ E) where
   toString b :=
     let (r, _) := NEList.foldl makePEBfs (id, b.posState) b.errors
     String.drop (r "") 1

--- a/Megaparsec/Errors/ParseError.lean
+++ b/Megaparsec/Errors/ParseError.lean
@@ -1,6 +1,8 @@
 import Megaparsec.Errors
+import Megaparsec.Printable
 
 open Megaparsec.Errors
+open Megaparsec.Printable
 
 namespace Megaparsec.Errors.ParseError
 
@@ -20,20 +22,20 @@ def errorOffset : ParseError β E → Nat
 
 section
 
-variable {β : Type u} [ToString β]
+variable {β : Type u} [Printable β]
 variable {E : Type u} [ToString E]
 
 def NEList.spanToLast (ne : NEList α) : (List α × α) :=
   let rec go
-    | .uno x, acc => (acc, x)
-    | .cons x xs, acc => go xs (x :: acc)
+    | ⟦x⟧, acc => (acc, x)
+    | x :| xs, acc => go xs (x :: acc)
   go ne []
 
 -- Print a pretty list where items are separated with commas and the word
 -- “or” according to the rules of English punctuation.
 def orList : NEList String → String
-  | .uno x => x
-  | .cons x (.uno y) => s!"{x} or {y}"
+  | ⟦x⟧ => x
+  | ⟦x,y⟧ => s!"{x} or {y}"
   | xs => let (lxs, last) := NEList.spanToLast xs
     String.intercalate ", " lxs ++ ", or " ++ last
 
@@ -43,7 +45,6 @@ def messageItemsPretty (pref : String) (ts : List String) : String :=
   | .none => ""
   | .some ts => s!"{pref} {orList ts}\n"
 
--- TODO: orig MP has `messageItemsPretty`, might want to add it. But it uses Set :(
 /-
   Pretty-print a textual part of a `ParseError`, that is, everything
   except for its position. The rendered `String` always ends with a

--- a/Megaparsec/Lisp.lean
+++ b/Megaparsec/Lisp.lean
@@ -5,6 +5,8 @@ import Megaparsec.Char
 import Megaparsec.String
 import Megaparsec.ParserState
 
+import YatimaStdLib
+
 open MonadParsec
 open Megaparsec.Parsec
 open Megaparsec.Common
@@ -76,7 +78,7 @@ structure LispLinearParsers where
   stringP :=
     s.label "string" $ do
     let (str : String) ←
-      between (c.char '"') (c.char '"') $
+      Seq.between (c.char '"') (c.char '"') $
         String.mk <$> (manyP m ℘ $ quoteAnyChar <|> c.noneOf "\\\"".data)
     pure $ fun r => Lisp.string (str, r)
   commentP := s.label "comment" $
@@ -94,7 +96,7 @@ mutual
   partial def listP : ParsecT m Char ℘ Unit (Range → Lisp) :=
     let p : LispLinearParsers m ℘ := {}
     p.s.label "list" $ do
-    between (p.c.char '(') (p.c.char ')') $ do
+    Seq.between (p.c.char '(') (p.c.char ')') $ do
       let ys ← sepEndByP m ℘ lispParser p.ignore
       pure $ fun r => Lisp.list (ys, r)
 

--- a/Megaparsec/MonadParsec.lean
+++ b/Megaparsec/MonadParsec.lean
@@ -300,7 +300,7 @@ instance [Monoid w] [Monad m]
     let (x, _, _) ← mₚ.lookAhead ℘ α E β (st r s)
     pure (x, s, One.one)
   notFollowedBy st := fun r s => do
-    mₚ.notFollowedBy ℘ α E β $ RWST.void $ st r s
+    mₚ.notFollowedBy ℘ α E β $ void $ st r s
     pure (Unit.unit, s, One.one)
   withRecovery φ p := fun r s =>
     mₚ.withRecovery ℘ α (fun e => (φ e) r s) (p r s)

--- a/Megaparsec/Parsec.lean
+++ b/Megaparsec/Parsec.lean
@@ -228,7 +228,7 @@ def parseTestP (p : Parsec β σ E γ) [ToString γ] [Printable β] [ToString E]
   | .left es => IO.println s!"{es}" >>= fun _ => pure $ (false, Either.left ())
   | .right y => IO.println y >>= fun _ => pure $ (true, Either.right y)
 
-def parseTest (p : Parsec β σ E γ) [ToString γ] [ToString β] [ToString E] (xs : σ) [Streamable σ] : String :=
+def parseTest (p : Parsec β σ E γ) [ToString γ] [Printable β] [ToString E] (xs : σ) [Streamable σ] : String :=
   match parseP p "" xs with
   | .left es => s!"Err: {es}"
   | .right y => s!"Ok: {y}"

--- a/Megaparsec/Parsec.lean
+++ b/Megaparsec/Parsec.lean
@@ -6,6 +6,7 @@ import Megaparsec.Errors.StreamErrors
 -- import Megaparsec.Errors.StreamErrors
 import Megaparsec.Ok
 import Megaparsec.ParserState
+import Megaparsec.Printable
 import Megaparsec.Streamable
 import Straume
 import Straume.Chunk
@@ -24,6 +25,7 @@ open Megaparsec.Errors
 -- open Megaparsec.Errors.StreamErrors
 open Megaparsec.Ok
 open Megaparsec.ParserState
+open Megaparsec.Printable
 open Megaparsec.Streamable
 
 open Straume
@@ -183,7 +185,7 @@ def runParserT' {m : Type u → Type v} {β σ E γ : Type u}
     | .err e => (s₁, .left (toBundle s₀ $ List.toNEList e s₁.parseErrors))
 
 def parseTestTP {m : Type → Type v} {β σ E : Type} {γ : Type}
-                (p : ParsecT m β σ E γ) (xs : σ) (srcName := "(test run)") [ToString E] [ToString β] [ToString γ] [Monad m] [MonadLiftT m IO] [Streamable σ]
+                (p : ParsecT m β σ E γ) (xs : σ) (srcName := "(test run)") [ToString E] [Printable β] [ToString γ] [Monad m] [MonadLiftT m IO] [Streamable σ]
                 : IO (Bool × Either Unit γ) := do
   let reply ← liftM $ runParserT' p (initialState srcName xs)
   match reply.2 with
@@ -208,7 +210,7 @@ def parseTP (p : ParsecT m β σ E γ) (srcName : String) (xs : σ) [Monad m] :=
     fun y => pure y.2
 
 /- Test some parser polymorphically. -/
-def parseTestP (p : Parsec β σ E γ) [ToString γ] [ToString β] [ToString E]
+def parseTestP (p : Parsec β σ E γ) [ToString γ] [Printable β] [ToString E]
   (xs : σ) [Streamable σ] : IO (Bool × Either Unit γ) :=
   match parseP p "" xs with
   | .left es => IO.println s!"{es}" >>= fun _ => pure $ (false, Either.left ())

--- a/Megaparsec/Printable.lean
+++ b/Megaparsec/Printable.lean
@@ -1,5 +1,6 @@
 import YatimaStdLib
 import Straume.Iterator
+import Straume.Bit
 
 open Straume.Iterator
 
@@ -93,3 +94,15 @@ instance : Printable String where
     match String.join $ go nl with
     | "" => "empty string"
     | joined => s!"\"{joined}\""
+
+instance : Printable UInt8 where
+  showTokens := stringPretty ∘ Functor.map (fun i => Char.ofNat $ i.toNat)
+
+open Bit in
+instance : Printable Bit where
+  showTokens
+    | ⟦b⟧ => s!"'{b}'"
+    | nl => let rec go xs := match xs with
+      | ⟦b⟧ => [toString b]
+      | b :| bs => toString b :: go bs
+      s!"\"{String.join $ go nl}\""

--- a/Megaparsec/Printable.lean
+++ b/Megaparsec/Printable.lean
@@ -1,0 +1,95 @@
+import YatimaStdLib
+import Straume.Iterator
+
+open Straume.Iterator
+
+namespace Megaparsec.Printable
+
+class Printable (β : Type u) where
+  -- Pretty-print non-empty list of tokens. This function is also used
+  -- to print single tokens (represented as singleton lists).
+  showTokens : NEList β → String
+
+  -- Return the number of characters that a non-empty list of tokens
+  -- spans. The default implementation is sufficient if every token spans
+  -- exactly 1 character.
+  tokensLength : NEList β → Nat := fun xs => xs.toList.length
+
+export Printable (showTokens tokensLength)
+
+--===========================================================--
+--========================= HELPERS =========================--
+--===========================================================--
+
+-- TODO: why are almost all escape sequences unrecognised by Lean?
+private def charPretty' : Char → Option String
+  -- | '\NUL' => .some "null"
+  -- | '\SOH' => .some "start of heading"
+  -- | '\STX' => .some "start of text"
+  -- | '\ETX' => .some "end of text"
+  -- | '\EOT' => .some "end of transmission"
+  -- | '\ENQ' => .some "enquiry"
+  -- | '\ACK' => .some "acknowledge"
+  -- | '\BEL' => .some "bell"
+  -- | '\BS' => .some "backspace"
+  | '\t' => .some "tab"
+  | '\n' => .some "newline"
+  -- | '\v' => .some "vertical tab"
+  -- | '\f' => .some "form feed"
+  | '\r' => .some "carriage return"
+  -- | '\SO' => .some "shift out"
+  -- | '\SI' => .some "shift in"
+  -- | '\DLE' => .some "data link escape"
+  -- | '\DC1' => .some "device control one"
+  -- | '\DC2' => .some "device control two"
+  -- | '\DC3' => .some "device control three"
+  -- | '\DC4' => .some "device control four"
+  -- | '\NAK' => .some "negative acknowledge"
+  -- | '\SYN' => .some "synchronous idle"
+  -- | '\ETB' => .some "end of transmission block"
+  -- | '\CAN' => .some "cancel"
+  -- | '\EM' => .some "end of medium"
+  -- | '\SUB' => .some "substitute"
+  -- | '\ESC' => .some "escape"
+  -- | '\FS' => .some "file separator"
+  -- | '\GS' => .some "group separator"
+  -- | '\RS' => .some "record separator"
+  -- | '\US' => .some "unit separator"
+  -- | '\DEL' => .some "delete"
+  -- | '\160' => .some "non-breaking space"
+  | _ => .none
+
+private def charPretty : Char → String
+  | ' ' => "space"
+  | ch  => (charPretty' ch).getD $ s!"'{ch}'"
+
+private def stringPretty : NEList Char → String
+  | ⟦x⟧ => charPretty x
+  | ⟦'\r','\n'⟧ => "crlf newline"
+  | xs =>
+    let f c := match charPretty' c with
+      | .none => s!"{c}"
+      | .some pretty => s!"<{pretty}>"
+    s!"\"{String.join $ f <$> xs.toList}\""
+
+--===========================================================--
+--=================== PRINTABLE INSTANCES ===================--
+--===========================================================--
+
+instance : Printable Char where
+  showTokens := stringPretty
+
+-- This isn't in the original MP, but we want to keep instances as
+-- simple as possible; consequently, we allow empty string be in the
+-- non-empty string list, but we don't represent it unless the whole
+-- list consists of a single empty string.
+instance : Printable String where
+  showTokens nl :=
+    let showStr str := (stringPretty <$> NEList.nonEmptyString str).getD ""
+    let rec go xs := match xs with
+      | ⟦x⟧ => [showStr x]
+      | "" :| xs => go xs
+      | x  :| xs => showStr x :: go xs
+    match String.join $ go nl with
+    | "" => "empty string"
+    | joined => s!"\"{joined}\""

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -10,7 +10,7 @@ require LSpec from git
   "https://github.com/yatima-inc/LSpec.git" @ "c63610bb23451c7aa2faae17c71e8d162c6c616e"
 
 require YatimaStdLib from git
-  "https://github.com/yatima-inc/YatimaStdLib.lean.git" @ "9c362443e0d89eb96683b52a1caaf762049697c4"
+  "https://github.com/yatima-inc/YatimaStdLib.lean.git" @ "54177756e0f3488979b05153872d1832bc5ba625"
 
 require Straume from git
   "https://github.com/yatima-inc/straume/" @ "c1d72a24ae3a8a8e0bd7928001b55958e4b9113c"


### PR DESCRIPTION
Problem: though printing errors right now kind of works, we want to make this even nicer by e.g. pretty-printing `Char`s, which make up the majority of out current usecases. This will print special characters in a readable manner.

Solution: based on a newer version of YatimaStdLib, switched error printing to a new Printable type class. Also cleaned up the rest a bit.