### PR TITLE
add top level accessors for MonadParsec methods

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -68,7 +68,7 @@ def main : IO Unit := do
   let P := Parsec Char String Unit
   let source := "yatimaaaa!"
   let bad := "yatimAaaa!"
-  let yp := string P String Unit Char "yatima"
+  let yp : P String := string "yatima"
   let x : (Bool × Either Unit String) <- parseTestP yp source
   if x.1 then
     IO.println "Well parsed."
@@ -79,7 +79,7 @@ def main : IO Unit := do
   IO.println "Let's see what isn't parsed after we parsed out `yatima`!"
   IO.println y.1.input
 
-  let ypp := (string P String Unit Char "yat") *> (string P String Unit Char "ima")
+  let ypp := (string "yat") *> (string "ima")
   let yb := rp bad ypp
   IO.println "Let's see how the parser fails."
   match yb.2 with
@@ -94,16 +94,17 @@ def main : IO Unit := do
   let S := (String × IO.FS.Handle)
   let Q := ParsecT IO Char S Unit
   -- let abcdp := (string Q S "abcd" <* MonadParsec.eof S String)
-  let abcdpnl := do
-    let res1 ← (string Q S Unit Char "ab")
-    let res2 ← (string Q S Unit Char "cd")
-    let _nl ← (string Q S Unit Char "\n")
-    let _eos ← (MonadParsec.eof S String Unit Char)
+  let abcdpnl : Q String := do
+    let res1 ← (string "ab")
+    let res2 ← (string "cd")
+    let _nl ← (string "\n")
+    let _eos ← Megaparsec.eof
     pure $ res1 ++ res2
   IO.println "Let's see if @ixahedron's test passes."
   let _ix : (Bool × Either Unit String) ← parseTestTP abcdpnl bh
   let h1 ← IO.FS.Handle.mk (System.mkFilePath ["./Tests", "abcd-no-nl.txt"]) IO.FS.Mode.read false
-  let _ixx : (Bool × Either Unit String) ← parseTestTP (string Q S Unit Char "abcd" <* MonadParsec.eof S String Unit Char) ("", h1)
+  let abcd : Q String := (string "abcd" <* MonadParsec.eof S String Unit Char)
+  let _ixx : (Bool × Either Unit String) ← parseTestTP abcd ("", h1)
 
   IO.println "Ergonomic version of @ixahedron's test."
   let file := System.mkFilePath ["./Tests", "abcd.txt"]

--- a/Megaparsec/Char.lean
+++ b/Megaparsec/Char.lean
@@ -22,9 +22,9 @@ variable (m : Type → Type v) (℘ E : Type) (α : Type := String)
 
 structure CharSimple where
   s : StringSimple m ℘ E := {}
-  char (x : Char) : m Char := single m ℘ E α x
-  char' (x : Char) : m Char := choice ℘ α E Char [ char x.toLower, char x.toUpper ]
-  anySingle : m Char := anySingle m ℘ α E
+  char (x : Char) : m Char := @single m ℘ α E Char inferInstance inferInstance x
+  char' (x : Char) : m Char := @choice m ℘ α E Char Char inferInstance inferInstance [ char x.toLower, char x.toUpper ]
+  anySingle : m Char := @anySingle m ℘ α E Char inferInstance
   newline := char '\n'
   cr := char '\r'
   crlf : m String := s.stringP "\r\n"
@@ -34,9 +34,9 @@ structure CharSimple where
       (newline *> pure "\n") <|> crlf
   eof : m Unit :=
     MonadParsec.eof ℘ α E Char
-  satisfy (f : Char → Bool) := satisfy m ℘ α E f
-  noneOf (xs : List Char) := noneOf m ℘ α E xs
-  oneOf (xs : List Char) := oneOf m ℘ α E xs
+  satisfy (f : Char → Bool) := @satisfy m ℘ α E Char inferInstance f
+  noneOf (xs : List Char) := @noneOf m ℘ α E Char inferInstance inferInstance xs
+  oneOf (xs : List Char) := @oneOf m ℘ α E Char inferInstance inferInstance xs
   tab : m Char := char '\t'
 
 def char_simple (℘x : Type) [MonadParsec (Parsec Char ℘x Unit) ℘x String Unit Char] : CharSimple (Parsec Char ℘x Unit) ℘x Unit := {}

--- a/Megaparsec/Common.lean
+++ b/Megaparsec/Common.lean
@@ -25,11 +25,11 @@ namespace Megaparsec.Common
 
 universe u
 
-def single (m : Type u → Type v) (℘ E α : Type u) (x : β) [MonadParsec m ℘ α E β] [BEq β] : m β :=
+def single {m : Type u → Type v} {℘ α E β: Type u} [MonadParsec m ℘ α E β] [BEq β] (x : β): m β :=
   MonadParsec.token ℘ α E (fun y => if x == y then .some x else .none) [ErrorItem.tokens $ NEList.uno x]
 
 -- TODO: case-insensitive version
-def string (m : Type u → Type v) (℘ E β : Type u) {α : Type u} (x : α) [MonadParsec m ℘ α E β] [BEq α] : m α :=
+def string {m : Type u → Type v} {℘ α E β: Type u} [MonadParsec m ℘ α E β] [BEq α] (x : α): m α :=
   MonadParsec.tokens ℘ E β (BEq.beq) x
 
 -- TODO: Move the following several fucntions to YatimaStdLib or even to Lean 4
@@ -41,7 +41,6 @@ def liftSeq2 [Seq φ] [Functor φ] (f2 : α → β → γ) (x : φ α) : (Unit �
 
 def void [Functor φ] (fx : φ a) : φ Unit :=
   (fun _ => ()) <$> fx
-
 
 -- TODO: A lot of thunks here. Support monadic versions of these combinators.
 -- TODO: Why doesn't generic version work? https://zulip.yatima.io/#narrow/stream/10-lean/topic/_spec_10.20constant.3F/near/19689
@@ -66,31 +65,35 @@ def void [Functor φ] (fx : φ a) : φ Unit :=
 -- end
 
 mutual
-  partial def some' (p : Parsec β ℘ Unit x) : Parsec β ℘ Unit (List x) := do
+  partial def some' {℘ β x: Type u} (p : Parsec β ℘ PUnit x) : Parsec β ℘ PUnit (List x) := do
     let y ← p
     let ys ← many' p
     pure $ List.cons y ys
-  partial def many' (p : Parsec β ℘ Unit x) : Parsec β ℘ Unit (List x) := do
+  partial def many' {℘ β x: Type u} (p : Parsec β ℘ PUnit x) : Parsec β ℘ PUnit (List x) := do
     some' p <|> pure []
 end
-partial def many1' (p : Parsec β ℘ Unit x) : Parsec β ℘ Unit (List x) := some' p
+partial def many1' {℘ β x : Type u} (p : Parsec β ℘ PUnit x) : Parsec β ℘ PUnit (List x) := some' p
 
 mutual
-  partial def some (m : Type u → Type v) (σ α β E : Type u) {γ : Type u} (p : m γ)
-                   [MonadParsec m σ α E β] [Monad m] [Alternative m]
+  partial def some {m : Type u → Type v} {σ α β E : Type u} {γ : Type u} 
+                   [pi: MonadParsec m σ α E β] [mi: Monad m] [ai: Alternative m]
+                   (p : m γ)
                    : m (List γ) := do
     let y ← p
-    let ys ← many m σ α β E p
+    let ys ← @many m σ α β E γ pi mi ai p
     pure $ List.cons y ys
-  partial def many (m : Type u → Type v) (σ α β E : Type u) {γ : Type u} (p : m γ)
-                   [MonadParsec m σ α E β] [Monad m] [Alternative m]
+  partial def many {m : Type u → Type v} {σ α β E : Type u} {γ : Type u} 
+                   [pi: MonadParsec m σ α E β] [mi: Monad m] [ai: Alternative m]
+                   (p : m γ)
                    : m (List γ) :=
-    some m σ α β E p <|> pure []
+    @some m σ α β E γ pi mi ai p <|> pure []
 end
-partial def many1 (m : Type u → Type v) (σ α β E : Type u) {γ : Type u} (p : m γ)
-                  [MonadParsec m σ α E β] [Monad m] [Alternative m]
+
+partial def many1 {m : Type u → Type v} {σ α β E : Type u} {γ : Type u} 
+                  [pi: MonadParsec m σ α E β] [mi: Monad m] [ai: Alternative m]
+                  (p : m γ)
                   : m (List γ) :=
-    some m σ α β E p
+    @some m σ α β E γ pi mi ai p
 
 -- mutual
 --   partial def sepEndBy1 [Alternative φ] [Inhabited (φ (List α))] (p : φ α) (sep : φ β) : φ (List α) :=
@@ -100,24 +103,26 @@ partial def many1 (m : Type u → Type v) (σ α β E : Type u) {γ : Type u} (p
 -- end
 
 mutual
-  partial def sepEndBy (m : Type u → Type v) (σ α β E : Type u) {γ : Type u} (p : m γ) (sep : m γ)
-                       [MonadParsec m σ α E β] [Monad m] [Alternative m]
+  partial def sepEndBy {m : Type u → Type v} {σ α β E : Type u} {γ : Type u}
+                       [pi: MonadParsec m σ α E β] [mi: Monad m] [ai: Alternative m]
+                       (p : m γ) (sep : m γ)
                        : m (List γ) :=
-    sepEndBy1 m σ α β E p sep <|> pure []
+    @sepEndBy1 m σ α β E γ pi mi ai p sep <|> pure []
 
-  partial def sepEndBy1 (m : Type u → Type v) (σ α β E : Type u) {γ : Type u} (p : m γ) (sep : m γ)
-                        [MonadParsec m σ α E β] [Monad m] [Alternative m]
-                        : m (List γ) := do
+  partial def sepEndBy1 {m : Type u → Type v} {σ α β E : Type u} {γ : Type u}
+                       [pi: MonadParsec m σ α E β] [mi: Monad m] [ai: Alternative m]
+                       (p : m γ) (sep : m γ)
+                       : m (List γ) := do
     let y ← p
-    let ys ← ((sep *> sepEndBy m σ α β E p sep) <|> pure [])
+    let ys ← ((sep *> @sepEndBy m σ α β E γ pi mi ai p sep) <|> pure [])
     pure $ List.cons y ys
 end
 
 mutual
-  partial def sepEndBy' (p : Parsec β ℘ Unit x) (sep : Parsec β ℘ Unit s) : Parsec β ℘ Unit (List x) :=
+  partial def sepEndBy' {℘ β x: Type u} (p : Parsec β ℘ PUnit x) (sep : Parsec β ℘ PUnit s) : Parsec β ℘ PUnit (List x) :=
     sepEndBy1' p sep <|> pure []
 
-  partial def sepEndBy1' (p : Parsec β ℘ Unit x) (sep : Parsec β ℘ Unit s) : Parsec β ℘ Unit (List x) := do
+  partial def sepEndBy1' {℘ β x: Type u} (p : Parsec β ℘ PUnit x) (sep : Parsec β ℘ PUnit s) : Parsec β ℘ PUnit (List x) := do
     let y ← p
     let ys ← ((sep *> sepEndBy' p sep) <|> pure [])
     pure $ List.cons y ys
@@ -133,24 +138,27 @@ end
 -- TODO: I absolutely hate the fact that we're not properly universe-polymorphic. I think it's a ripple effect of buggy Foldable.
 -- And the fact that we're not doing universe-lifting for primitive types.
 
-def choice' {m : Type → Type v} {β σ E γ : Type} (ps : List (ParsecT m β σ E γ)) : ParsecT m β σ E γ :=
+def choice' {m : Type → Type v} {β σ E γ : Type} (ps : List (ParsecT m β σ E γ))
+  : ParsecT m β σ E γ :=
   List.foldr (fun a b => a <|> b) Alternative.failure ps
 
 /- m-polymorphic choice -/
-def choice {m : Type → Type v} (σ α E β : Type) {γ : Type} (ps : List (m γ)) [MonadParsec m σ α E β] [Alternative m] : m γ :=
+def choice {m : Type → Type v} {σ α E β : Type} {γ : Type} [MonadParsec m σ α E β] [Alternative m] 
+  (ps : List (m γ)) 
+  : m γ :=
   List.foldr (fun a b => a <|> b) Alternative.failure ps
 
 /- m-polymorphic noneOf -/
 -- def noneOf {m : Type → Type v} [MonadParsec m σ α E β]
 
-def satisfy (m : Type u → Type v) (σ α E : Type u) {β : Type u} (f : β → Bool) [MonadParsec m σ α E β] : m β :=
+def satisfy {m : Type u → Type v} {σ α E β : Type u} [MonadParsec m σ α E β] (f : β → Bool) : m β :=
   MonadParsec.token σ α E (fun x => if f x then .some x else .none) []
 
-def anySingle (m : Type u → Type v) (σ α E : Type u) {β : Type u} [MonadParsec m σ α E β] : m β :=
-  satisfy m σ α E (fun _ => true)
+def anySingle {m : Type u → Type v} {σ α E β : Type u} [i: MonadParsec m σ α E β] : m β :=
+  @satisfy m σ α E β i (fun _ => true)
 
-def noneOf (m : Type u → Type v) (σ α E : Type u) {β : Type u} (cs : List β) [BEq β] [MonadParsec m σ α E β] : m β :=
-  satisfy m σ α E $ fun c => (cs.indexOf? c).isNone
+def noneOf {m : Type u → Type v} {σ α E β : Type u} [BEq β] [i: MonadParsec m σ α E β] (cs : List β): m β :=
+  @satisfy m σ α E β i $ fun c => (cs.indexOf? c).isNone
 
-def oneOf (m : Type u → Type v) (σ α E : Type u) {β : Type u} (cs : List β) [BEq β] [MonadParsec m σ α E β] : m β :=
-  satisfy m σ α E $ fun c => (cs.indexOf? c).isSome
+def oneOf {m : Type u → Type v} {σ α E β: Type u} [BEq β] [i: MonadParsec m σ α E β] (cs : List β): m β :=
+  @satisfy m σ α E β i $ fun c => (cs.indexOf? c).isSome

--- a/Megaparsec/MonadParsec.lean
+++ b/Megaparsec/MonadParsec.lean
@@ -110,6 +110,7 @@ private def nelstr (x : Char) (xs : String) := match NEList.nonEmptyString xs wi
   | .some xs' => NEList.cons x xs'
   | .none => NEList.uno x
 
+@[defaultInstance]
 instance theInstance {m : Type u → Type v} {α β σ E : Type u}
                      [Monad m] [Iterable α β] [Iterable.Bijection β α] [Inhabited α] [@Straume m σ Chunk α β]
                      : MonadParsec (ParsecT m β σ E) σ α E β where
@@ -312,65 +313,65 @@ namespace Megaparsec
 
 open MonadParsec
 
-def parseError {m: Type u → Type v} {℘ α E β: Type u} (_: MonadParsec m ℘ α E β) {γ : Type u}
+def parseError {m: Type u → Type v} {℘ α E β: Type u} [MonadParsec m ℘ α E β] {γ : Type u}
   : Megaparsec.Errors.ParseError.ParseError β E → m γ :=
   MonadParsec.MonadParsec.parseError ℘ α
 
-def label {m: Type u → Type v} {℘ α E β: Type u} (_:MonadParsec.MonadParsec m ℘ α E β) {γ : Type u}
+def label {m: Type u → Type v} {℘ α E β: Type u} [MonadParsec.MonadParsec m ℘ α E β] {γ : Type u}
   : String → m γ → m γ :=
   MonadParsec.MonadParsec.label ℘ α E β
 
-def hidden {m: Type u → Type v} {℘ α E β: Type u} (_:MonadParsec.MonadParsec m ℘ α E β) {γ : Type u}
+def hidden {m: Type u → Type v} {℘ α E β: Type u} [MonadParsec.MonadParsec m ℘ α E β] {γ : Type u}
   : m γ → m γ :=
   MonadParsec.MonadParsec.hidden ℘ α E β
 
-def attempt {m: Type u → Type v} {℘ α E β: Type u} (_:MonadParsec.MonadParsec m ℘ α E β) {γ : Type u}
+def attempt {m: Type u → Type v} {℘ α E β: Type u} [MonadParsec.MonadParsec m ℘ α E β] {γ : Type u}
   : m γ → m γ :=
   MonadParsec.MonadParsec.attempt ℘ α E β
 
-def lookAhead {m: Type u → Type v} {℘ α E β: Type u} (_:MonadParsec.MonadParsec m ℘ α E β) {γ : Type u}
+def lookAhead {m: Type u → Type v} {℘ α E β: Type u} [MonadParsec.MonadParsec m ℘ α E β] {γ : Type u}
   : m γ → m γ :=
   MonadParsec.MonadParsec.lookAhead ℘ α E β
 
-def notFollowedBy {m: Type u → Type v} {℘ α E β: Type u} (_:MonadParsec.MonadParsec m ℘ α E β) {γ : Type u}
+def notFollowedBy {m: Type u → Type v} {℘ α E β: Type u} [MonadParsec.MonadParsec m ℘ α E β] {γ : Type u}
   : m γ → m PUnit :=
   MonadParsec.MonadParsec.notFollowedBy ℘ α E β
 
-def withRecovery {m: Type u → Type v} {℘ α E β: Type u} (_:MonadParsec.MonadParsec m ℘ α E β) {γ : Type u}
+def withRecovery {m: Type u → Type v} {℘ α E β: Type u} [MonadParsec.MonadParsec m ℘ α E β] {γ : Type u}
   : (Megaparsec.Errors.ParseError.ParseError β E → m γ) → m γ → m γ :=
   MonadParsec.MonadParsec.withRecovery ℘ α
 
-def observing {m: Type u → Type v} {℘ α E β: Type u} (_:MonadParsec.MonadParsec m ℘ α E β) {γ : Type u}
+def observing {m: Type u → Type v} {℘ α E β: Type u} [MonadParsec.MonadParsec m ℘ α E β] {γ : Type u}
   : m γ → m (Either (Megaparsec.Errors.ParseError.ParseError β E) γ) :=
   MonadParsec.MonadParsec.observing ℘ α
 
-def eof {m: Type u → Type v} {℘ α E β: Type u} (_:MonadParsec.MonadParsec m ℘ α E β) : m PUnit :=
+def eof {m: Type u → Type v} {℘ α E β: Type u} [MonadParsec.MonadParsec m ℘ α E β] : m PUnit :=
   MonadParsec.MonadParsec.eof ℘ α E β
 
-def token {m: Type u → Type v} {℘ α E β: Type u} (_:MonadParsec.MonadParsec m ℘ α E β) 
+def token {m: Type u → Type v} {℘ α E β: Type u} [MonadParsec.MonadParsec m ℘ α E β]
   : (β → Option γ) → (List (Megaparsec.Errors.ErrorItem β)) → m γ :=
   MonadParsec.MonadParsec.token ℘ α E
 
-def tokens {m: Type u → Type v} {℘ α E β: Type u} (_:MonadParsec.MonadParsec m ℘ α E β) 
-  : (β → Option γ) → (List (Megaparsec.Errors.ErrorItem β)) → m γ :=
-  MonadParsec.MonadParsec.tokens ℘ α E
+def tokens {m: Type u → Type v} {℘ α E β: Type u} [MonadParsec.MonadParsec m ℘ α E β]
+  : (α → α → Bool) → α → m α :=
+  MonadParsec.MonadParsec.tokens ℘ E β
 
-def takeWhileP {m: Type u → Type v} {℘ α E β: Type u} (_:MonadParsec.MonadParsec m ℘ α E β) 
+def takeWhileP {m: Type u → Type v} {℘ α E β: Type u} [MonadParsec.MonadParsec m ℘ α E β] 
   : Option String → (β → Bool) → m α :=
   MonadParsec.MonadParsec.takeWhileP ℘ E
 
-def takeWhile1P {m: Type u → Type v} {℘ α E β: Type u} (_:MonadParsec.MonadParsec m ℘ α E β) 
+def takeWhile1P {m: Type u → Type v} {℘ α E β: Type u} [MonadParsec.MonadParsec m ℘ α E β] 
   : Option String → (β → Bool) → m α :=
   MonadParsec.MonadParsec.takeWhile1P ℘ E
 
-def takeP {m: Type u → Type v} {℘ α E β: Type u} (_: MonadParsec.MonadParsec m ℘ α E β) : Option String -> Nat -> m α :=
+def takeP {m: Type u → Type v} {℘ α E β: Type u} [ MonadParsec.MonadParsec m ℘ α E β] : Option String -> Nat -> m α :=
   MonadParsec.MonadParsec.takeP ℘ E β
 
-def getParserState {m: Type u → Type v} {℘ α E β: Type u} (_: MonadParsec.MonadParsec m ℘ α E β) 
+def getParserState {m: Type u → Type v} {℘ α E β: Type u} [MonadParsec.MonadParsec m ℘ α E β]
   : m (Megaparsec.ParserState.State β ℘ E) :=
   MonadParsec.MonadParsec.getParserState α
 
-def updateParserState {m: Type u → Type v} {℘ α E β: Type u} (_: MonadParsec.MonadParsec m ℘ α E β) 
+def updateParserState {m: Type u → Type v} {℘ α E β: Type u} [MonadParsec.MonadParsec m ℘ α E β]
   : (Megaparsec.ParserState.State β ℘ E → Megaparsec.ParserState.State β ℘ E)-> m PUnit :=
   MonadParsec.MonadParsec.updateParserState α
 

--- a/Megaparsec/MonadParsec.lean
+++ b/Megaparsec/MonadParsec.lean
@@ -353,7 +353,7 @@ def token {m: Type u → Type v} {℘ α E β: Type u} (_:MonadParsec.MonadParse
 
 def tokens {m: Type u → Type v} {℘ α E β: Type u} (_:MonadParsec.MonadParsec m ℘ α E β) 
   : (β → Option γ) → (List (Megaparsec.Errors.ErrorItem β)) → m γ :=
-  MonadParsec.MonadParsec.token ℘ α E
+  MonadParsec.MonadParsec.tokens ℘ α E
 
 def takeWhileP {m: Type u → Type v} {℘ α E β: Type u} (_:MonadParsec.MonadParsec m ℘ α E β) 
   : Option String → (β → Bool) → m α :=
@@ -373,4 +373,5 @@ def getParserState {m: Type u → Type v} {℘ α E β: Type u} (_: MonadParsec.
 def updateParserState {m: Type u → Type v} {℘ α E β: Type u} (_: MonadParsec.MonadParsec m ℘ α E β) 
   : (Megaparsec.ParserState.State β ℘ E → Megaparsec.ParserState.State β ℘ E)-> m PUnit :=
   MonadParsec.MonadParsec.updateParserState α
+
 end Megaparsec

--- a/Megaparsec/MonadParsec.lean
+++ b/Megaparsec/MonadParsec.lean
@@ -305,3 +305,72 @@ def withRange (α : Type u) (p : ParsecT m β σ E (Range → γ)) [MonadParsec 
   let s₁ : State β σ E ← MonadParsec.getParserState α
   let last := s₁.posState.sourcePos
   pure $ go (Range.mk first last)
+
+end MonadParsec
+
+namespace Megaparsec
+
+open MonadParsec
+
+def parseError {m: Type u → Type v} {℘ α E β: Type u} (_: MonadParsec m ℘ α E β) {γ : Type u}
+  : Megaparsec.Errors.ParseError.ParseError β E → m γ :=
+  MonadParsec.MonadParsec.parseError ℘ α
+
+def label {m: Type u → Type v} {℘ α E β: Type u} (_:MonadParsec.MonadParsec m ℘ α E β) {γ : Type u}
+  : String → m γ → m γ :=
+  MonadParsec.MonadParsec.label ℘ α E β
+
+def hidden {m: Type u → Type v} {℘ α E β: Type u} (_:MonadParsec.MonadParsec m ℘ α E β) {γ : Type u}
+  : m γ → m γ :=
+  MonadParsec.MonadParsec.hidden ℘ α E β
+
+def attempt {m: Type u → Type v} {℘ α E β: Type u} (_:MonadParsec.MonadParsec m ℘ α E β) {γ : Type u}
+  : m γ → m γ :=
+  MonadParsec.MonadParsec.attempt ℘ α E β
+
+def lookAhead {m: Type u → Type v} {℘ α E β: Type u} (_:MonadParsec.MonadParsec m ℘ α E β) {γ : Type u}
+  : m γ → m γ :=
+  MonadParsec.MonadParsec.lookAhead ℘ α E β
+
+def notFollowedBy {m: Type u → Type v} {℘ α E β: Type u} (_:MonadParsec.MonadParsec m ℘ α E β) {γ : Type u}
+  : m γ → m PUnit :=
+  MonadParsec.MonadParsec.notFollowedBy ℘ α E β
+
+def withRecovery {m: Type u → Type v} {℘ α E β: Type u} (_:MonadParsec.MonadParsec m ℘ α E β) {γ : Type u}
+  : (Megaparsec.Errors.ParseError.ParseError β E → m γ) → m γ → m γ :=
+  MonadParsec.MonadParsec.withRecovery ℘ α
+
+def observing {m: Type u → Type v} {℘ α E β: Type u} (_:MonadParsec.MonadParsec m ℘ α E β) {γ : Type u}
+  : m γ → m (Either (Megaparsec.Errors.ParseError.ParseError β E) γ) :=
+  MonadParsec.MonadParsec.observing ℘ α
+
+def eof {m: Type u → Type v} {℘ α E β: Type u} (_:MonadParsec.MonadParsec m ℘ α E β) : m PUnit :=
+  MonadParsec.MonadParsec.eof ℘ α E β
+
+def token {m: Type u → Type v} {℘ α E β: Type u} (_:MonadParsec.MonadParsec m ℘ α E β) 
+  : (β → Option γ) → (List (Megaparsec.Errors.ErrorItem β)) → m γ :=
+  MonadParsec.MonadParsec.token ℘ α E
+
+def tokens {m: Type u → Type v} {℘ α E β: Type u} (_:MonadParsec.MonadParsec m ℘ α E β) 
+  : (β → Option γ) → (List (Megaparsec.Errors.ErrorItem β)) → m γ :=
+  MonadParsec.MonadParsec.token ℘ α E
+
+def takeWhileP {m: Type u → Type v} {℘ α E β: Type u} (_:MonadParsec.MonadParsec m ℘ α E β) 
+  : Option String → (β → Bool) → m α :=
+  MonadParsec.MonadParsec.takeWhileP ℘ E
+
+def takeWhile1P {m: Type u → Type v} {℘ α E β: Type u} (_:MonadParsec.MonadParsec m ℘ α E β) 
+  : Option String → (β → Bool) → m α :=
+  MonadParsec.MonadParsec.takeWhile1P ℘ E
+
+def takeP {m: Type u → Type v} {℘ α E β: Type u} (_: MonadParsec.MonadParsec m ℘ α E β) : Option String -> Nat -> m α :=
+  MonadParsec.MonadParsec.takeP ℘ E β
+
+def getParserState {m: Type u → Type v} {℘ α E β: Type u} (_: MonadParsec.MonadParsec m ℘ α E β) 
+  : m (Megaparsec.ParserState.State β ℘ E) :=
+  MonadParsec.MonadParsec.getParserState α
+
+def updateParserState {m: Type u → Type v} {℘ α E β: Type u} (_: MonadParsec.MonadParsec m ℘ α E β) 
+  : (Megaparsec.ParserState.State β ℘ E → Megaparsec.ParserState.State β ℘ E)-> m PUnit :=
+  MonadParsec.MonadParsec.updateParserState α
+end Megaparsec

--- a/Megaparsec/Parsec.lean
+++ b/Megaparsec/Parsec.lean
@@ -225,3 +225,8 @@ def parseTestP (p : Parsec β σ E γ) [ToString γ] [ToString β] [ToString E]
   match parseP p "" xs with
   | .left es => IO.println s!"{es}" >>= fun _ => pure $ (false, Either.left ())
   | .right y => IO.println y >>= fun _ => pure $ (true, Either.right y)
+
+def parseTest (p : Parsec β σ E γ) [ToString γ] [ToString β] [ToString E] (xs : σ) [Streamable σ] : String :=
+  match parseP p "" xs with
+  | .left es => s!"Err: {es}"
+  | .right y => s!"Ok: {y}"


### PR DESCRIPTION
This allows the following:

```lean
import Megaparsec.Parsec
import Megaparsec.MonadParsec


inductive Error where
| err : String -> Error

instance : ToString Error where
  toString
  | .err s => s

abbrev ParserT (m: Type → Type) := Megaparsec.Parsec.ParsecT m Char String Error

abbrev Parser := ParserT Id

def parseTestPrint (p : Megaparsec.Parsec.Parsec β σ E γ) [ToString γ] [ToString β] [ToString E]
  (xs : σ) [Megaparsec.Streamable.Streamable σ] : String :=
  match Megaparsec.Parsec.parseP p "" xs with
  | .left es => s!"Err: {es}"
  | .right y => s!"Ok: {y}"

abbrev i := @MonadParsec.theInstance

def p : Parser String := do
  let x <- Megaparsec.takeP i .none 3
  Megaparsec.eof i
  pure x

#eval parseTestPrint p "foo" -- "Ok: foo"
```