### PR TITLE
[#23] Fix off-by-one in error offsets

### DIFF
--- a/Megaparsec/Errors/StreamErrors.lean
+++ b/Megaparsec/Errors/StreamErrors.lean
@@ -15,11 +15,6 @@ namespace Megaparsec.Errors.StreamErrors
 
 universe u
 
-def errorOffset (e: ParseError β E) : Nat :=
-  match e with
-    | ParseError.trivial n _ _ => n
-    | ParseError.fancy n _     => n
-
 /- Merge errors produced by alternative parsers.
 Strategy:
 

--- a/Megaparsec/ParserState.lean
+++ b/Megaparsec/ParserState.lean
@@ -24,6 +24,10 @@ def sourcePosPretty : SourcePos → String
   | ⟨n, l, c⟩ => let lcStr := s!"{l.pos}:{c.pos}"
     if n.isEmpty then lcStr else s!"{n}:{lcStr}"
 
+def initialSourcePos (sourceName : String) : SourcePos :=
+  let p₁ := Pos.mk 1
+  ⟨sourceName, p₁, p₁⟩
+
 structure Range where
   first : SourcePos
   last : SourcePos
@@ -66,8 +70,10 @@ def longestMatch (s₁ : @State β ℘ E) (s₂ : @State β ℘ E) : @State β �
     | Ordering.eq => s₂
     | Ordering.gt => s₁
 
+private def defaultTabWidth : Nat := 2
+
 /- State smart constructor. -/
 def initialState (sourceName : String) (xs : ℘) : @State β ℘ E :=
-  let p₀ := Pos.mk 0
-  let posState := PosState.mk xs 0 (SourcePos.mk sourceName p₀ p₀) 2 ""
+  let sourcePos := initialSourcePos sourceName
+  let posState := PosState.mk xs 0 sourcePos defaultTabWidth ""
   State.mk xs 0 posState []

--- a/Megaparsec/Printable.lean
+++ b/Megaparsec/Printable.lean
@@ -1,6 +1,5 @@
 import YatimaStdLib
 import Straume.Iterator
-import Straume.Bit
 
 open Straume.Iterator
 
@@ -98,7 +97,7 @@ instance : Printable String where
 instance : Printable UInt8 where
   showTokens := stringPretty ∘ Functor.map (fun i => Char.ofNat $ i.toNat)
 
-open Bit in
+open ByteArray in
 instance : Printable Bit where
   showTokens
     | ⟦b⟧ => s!"'{b}'"

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -7,13 +7,13 @@ package Megaparsec
 lean_lib Megaparsec
 
 require LSpec from git
-  "https://github.com/yatima-inc/LSpec.git" @ "c63610bb23451c7aa2faae17c71e8d162c6c616e"
+  "https://github.com/yatima-inc/LSpec.git" @ "9c9f3cc9f3148c1b2d6071a35e54e4c5392373b7"
 
 require YatimaStdLib from git
-  "https://github.com/yatima-inc/YatimaStdLib.lean.git" @ "54177756e0f3488979b05153872d1832bc5ba625"
+  "https://github.com/yatima-inc/YatimaStdLib.lean.git" @ "876d29cb6f8011119a74712de7cb86280e408e3b"
 
 require Straume from git
-  "https://github.com/yatima-inc/straume/" @ "c1d72a24ae3a8a8e0bd7928001b55958e4b9113c"
+  "https://github.com/yatima-inc/straume/" @ "fa32bbbc9942c2339e5d363ef5af1e5af081470b"
 
 @[defaultTarget]
 lean_exe megaparsec {


### PR DESCRIPTION
Problem: our errors currently pretty-print nicely, except that both the line and column numbers and the pointer are off-by-one, which makes the error reporting less useful. The reason for this is that the initial source position for the parser state is initialised with zero for both line and column number, whereas it should be, and is in the reference implementation, set to 1.

Solution: changed the initial positions to 1.
Also changed all Bit references to the one from YatimaStdLib.

_______

Closes #23.