### PR TITLE
[#11] Unduplicated errors

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -108,6 +108,13 @@ def testStateT : IO Unit := do
       | imp => IO.println s!"Impossible error in testStateT ({imp})"
     | .left _ => IO.println "Error #3 in testStateT"
 
+def duplicateErrorsTest : IO Unit := do
+  IO.println "Let's make sure that duplicate errors aren't reported!"
+  IO.println "The expected list should include 'yatima' and 'yatima!'"
+  IO.println "one time each, instead of 'yatima' being reported twice."
+  let p  : Parsec Char String Unit String := string "yatima"
+  let p' : Parsec Char String Unit String := string "yatima!"
+  let _ ← parseTestP (p <|> p <|> p') "Yatima"
 
 def main : IO Unit := do
   IO.println "Megaparsec demo!"
@@ -134,6 +141,9 @@ def main : IO Unit := do
   | .right _ => IO.println "Hmm, the parser didn't fail. That's a bug!"
   IO.println "But let's make sure that ypp parser actually works."
   let _yg : (Bool × Either Unit String) ← parseTestP ypp source
+
+  IO.println ""
+  duplicateErrorsTest
 
   let file := System.mkFilePath ["./Tests", "abcd.txt"]
   let h ← IO.FS.Handle.mk file IO.FS.Mode.read false

--- a/Megaparsec/Common.lean
+++ b/Megaparsec/Common.lean
@@ -25,22 +25,27 @@ namespace Megaparsec.Common
 
 universe u
 
-def single {m : Type u → Type v} {℘ α E β: Type u} [MonadParsec m ℘ α E β] [BEq β] (x : β) : m β :=
+section
+
+def single {m : Type u → Type v} {℘ α E β : Type u} [MonadParsec m ℘ α E β] [BEq β] (x : β) : m β :=
   MonadParsec.token ℘ α E (fun y => if x == y then .some x else .none) [ErrorItem.tokens $ NEList.uno x]
 
 -- TODO: case-insensitive version
-def string {m : Type u → Type v} {℘ α E β: Type u} [MonadParsec m ℘ α E β] [BEq α] (x : α) : m α :=
+def string {m : Type u → Type v} {℘ α E β : Type u} [MonadParsec m ℘ α E β] [BEq α] (x : α) : m α :=
   MonadParsec.tokens ℘ E β (BEq.beq) x
 
+instance : Ord PUnit where
+  compare | _, _ => .eq
+
 mutual
-  partial def some' {℘ β x: Type u} (p : Parsec β ℘ PUnit x) : Parsec β ℘ PUnit (List x) := do
+  partial def some' {℘ β x : Type u} [Alternative (Parsec β ℘ PUnit)] (p : Parsec β ℘ PUnit x) : Parsec β ℘ PUnit (List x) := do
     let y ← p
     let ys ← many' p
     pure $ List.cons y ys
-  partial def many' {℘ β x: Type u} (p : Parsec β ℘ PUnit x) : Parsec β ℘ PUnit (List x) := do
+  partial def many' {℘ β x : Type u} [Alternative (Parsec β ℘ PUnit)] (p : Parsec β ℘ PUnit x) : Parsec β ℘ PUnit (List x) := do
     some' p <|> pure []
 end
-partial def many1' {℘ β x : Type u} (p : Parsec β ℘ PUnit x) : Parsec β ℘ PUnit (List x) := some' p
+partial def many1' {℘ β x : Type u} [Alternative (Parsec β ℘ PUnit)] (p : Parsec β ℘ PUnit x) : Parsec β ℘ PUnit (List x) := some' p
 
 mutual
   partial def some {m : Type u → Type v} {℘ α β E : Type u} {γ : Type u}
@@ -87,13 +92,15 @@ mutual
 end
 
 mutual
-  partial def sepEndBy' {℘ β x: Type u} (p : Parsec β ℘ PUnit x) (sep : Parsec β ℘ PUnit s) : Parsec β ℘ PUnit (List x) :=
+  partial def sepEndBy' {℘ β x : Type u} [Alternative (Parsec β ℘ PUnit)] (p : Parsec β ℘ PUnit x) (sep : Parsec β ℘ PUnit s) : Parsec β ℘ PUnit (List x) :=
     sepEndBy1' p sep <|> pure []
 
-  partial def sepEndBy1' {℘ β x : Type u} (p : Parsec β ℘ PUnit x) (sep : Parsec β ℘ PUnit s) : Parsec β ℘ PUnit (List x) := do
+  partial def sepEndBy1' {℘ β x : Type u} [Alternative (Parsec β ℘ PUnit)] (p : Parsec β ℘ PUnit x) (sep : Parsec β ℘ PUnit s) : Parsec β ℘ PUnit (List x) := do
     let y ← p
     let ys ← ((sep *> sepEndBy' p sep) <|> pure [])
     pure $ List.cons y ys
+end
+
 end
 
 -- -- TODO: Our foldable is not foldable: https://zulip.yatima.io/#narrow/stream/24-yatima-tools/topic/.5BYatimaStdLib.2Elean.5D.20chat/near/19242
@@ -106,7 +113,7 @@ end
 -- TODO: I absolutely hate the fact that we're not properly universe-polymorphic. I think it's a ripple effect of buggy Foldable.
 -- And the fact that we're not doing universe-lifting for primitive types.
 
-def choice' {m : Type → Type v} {β ℘ E γ : Type} (ps : List (ParsecT m β ℘ E γ))
+def choice' {m : Type → Type v} {β ℘ E γ : Type} (ps : List (ParsecT m β ℘ E γ)) [Alternative (ParsecT m β ℘ E)]
   : ParsecT m β ℘ E γ :=
   List.foldr (fun a b => a <|> b) Alternative.failure ps
 
@@ -118,6 +125,8 @@ def choice {m : Type → Type v} {℘ α E β : Type} {γ : Type} [MonadParsec m
 
 /- m-polymorphic noneOf -/
 -- def noneOf {m : Type → Type v} [MonadParsec m ℘ α E β]
+
+section
 
 def satisfy {m : Type u → Type v} {℘ α E β : Type u} [MonadParsec m ℘ α E β] (f : β → Bool) : m β :=
   MonadParsec.token ℘ α E (fun x => if f x then .some x else .none) []
@@ -134,13 +143,17 @@ def oneOf {m : Type u → Type v} {℘ α E β: Type u} [BEq β] [i: MonadParsec
 /- Even if the parser `p` fails, `option'` succeds without consuming input.
 Otherwise, it succeeds with consuming input. -/
 def option' {m : Type u → Type v} {℘ β x : Type u}
-            (p : ParsecT m β ℘ PUnit x) : ParsecT m β ℘ PUnit (Option x) :=
+            [Alternative (ParsecT m β ℘ PUnit)] (p : ParsecT m β ℘ PUnit x)
+            : ParsecT m β ℘ PUnit (Option x) :=
   (p >>= fun y => pure $ .some y) <|> pure none
 
 /- Even if the parser `p` fails, `option'` succeds without consuming input.
 Otherwise, it succeeds with consuming input. -/
-def option'' {℘ β x : Type u} (p : Parsec β ℘ PUnit x) : Parsec β ℘ PUnit (Option x) :=
-  @option' Id ℘ β x p
+def option'' {℘ β x : Type u} [a : Alternative (Parsec β ℘ PUnit)] (p : Parsec β ℘ PUnit x)
+             : Parsec β ℘ PUnit (Option x) :=
+  @option' Id ℘ β x a p
+
+end
 
 /- m-polymorphic option -/
 def option {m : Type → Type v} {℘ α E β : Type} {γ : Type}

--- a/Megaparsec/Err.lean
+++ b/Megaparsec/Err.lean
@@ -2,6 +2,12 @@ import Megaparsec.Errors
 import Megaparsec.Errors.ParseError
 import Megaparsec.ParserState
 
+import YatimaStdLib
+
+open Std (RBMap)
+
+open Std.RBMap (unitMap)
+
 open Megaparsec.Errors
 open Megaparsec.Errors.ParseError
 open Megaparsec.ParserState
@@ -16,7 +22,9 @@ def Err (m : Type f → Type v) (β ℘ E : Type u) (ξ : Type f) :=
 hints @hs@ to third argument of original continuation c.
 -/
 def withHints (hs : Hints β)
-              (f : Err m β ℘ γ ξ) : Err m β ℘ γ ξ :=
+              (f : Err m β ℘ E ξ) : Err m β ℘ E ξ :=
   fun e => match e with
-  | .trivial pos us hs₀ => f $ .trivial pos us (List.join $ hs₀ :: hs)
+  | .trivial pos us hs₀ =>
+      let hs' := unitMap $ List.join hs
+      f $ .trivial pos us $ hs₀ ++ hs'
   | _ => f e

--- a/Megaparsec/Errors.lean
+++ b/Megaparsec/Errors.lean
@@ -17,6 +17,20 @@ inductive ErrorItem (β : Type u) where
   | tokens (t : NEList β)
   | label (l : NEList Char)
   | eof
+  deriving BEq
+
+instance [Ord β] : Ord (ErrorItem β) where
+  compare
+    | .tokens t1, .tokens t2 => compare t1 t2
+    | .label l1, .label l2 => compare l1 l2
+    | .eof, .eof => .eq
+    -- tokens are said to be greater than anything
+    | .tokens _, _ => .gt
+    -- labels are said to be greater than anything but tokens
+    | .label _, .tokens _ => .lt
+    | .label _, _ => .gt
+    -- eof is said to be less than anything
+    | .eof, _ => .lt
 
 def errorItemLength [Printable β] : ErrorItem β → Nat
   | .tokens t => tokensLength t
@@ -53,10 +67,55 @@ instance ord2beq_ei : BEq (ErrorItem γ) where
     | .eof, .eof => true
     | _, _ => false
 
+section ErrorFancy
+
 inductive ErrorFancy (E : Type u) where
   | fail (msg : String)
   | indent (ord : Ordering) (fromPos : Pos) (uptoPos : Pos)
   | custom (e : E)
+
+private def compareOrderings : Ordering → Ordering → Ordering
+  | .gt, .gt => .eq
+  | .gt,   _ => .gt
+  | .eq, .gt => .lt
+  | .eq, .eq => .eq
+  | .eq, .lt => .gt
+  | .lt, .lt => .eq
+  | .lt,   _ => .lt
+
+/-
+  A method to compare indent triples for purposes of the `Ord (ErrorFancy E)`
+  instance.
+
+  The `.indent` constructor has the following fields (not in this order):
+    - `uptoPos : Pos`, the actual indentation level
+    - `fromPos : Pos`, the reference indentation level
+    - `ord : Ordering`, the difference (greater than, equal, less than) between
+    the reference and the actual indentation levels.
+
+  As such, we first compare on the actual levels, then on reference,
+  and then, as a last resort, on the difference between them.
+-/
+private def compareIndents : (Ordering × Pos × Pos) → (Ordering × Pos × Pos)
+                           → Ordering
+  | (o1, f1, u1), (o2, f2, u2) =>
+    match compare u1 u2, compare f1 f2 with
+                  -- we compare orderings as that's the last differing parameter
+    | .eq, .eq => compareOrderings o1 o2
+    | .eq,  fo => fo
+    |  fu,   _ => fu
+
+instance [Ord E] : Ord (ErrorFancy E) where
+  compare
+    | .fail m1, .fail m2 => compare m1 m2
+    | .fail _, _ => .gt
+    | .custom e1, .custom e2 => compare e1 e2
+    | .custom _, _ => .lt
+    | .indent o1 f1 u1, .indent o2 f2 u2 =>
+        compareIndents (o1, f1, u1) (o2, f2, u2)
+    | .indent _ _ _, .fail _ => .lt
+    | .indent _ _ _, .custom _ => .gt
+
 
 -- TODO: the og MP defines a `ShowErrorComponent` type class that has an
 -- `errorComponentLen` method that would be used here. However, AFAICT it's
@@ -75,5 +134,7 @@ instance [ToString E] : ToString (ErrorFancy E) where
     | .eq => "equal to"
     | .gt => "greater than"
     s!"incorrect indentation (got {uptoPos.pos}, should be {rel} {fromPos.pos})"
+
+end ErrorFancy
 
 end Megaparsec.Errors

--- a/Megaparsec/Errors/Bundle.lean
+++ b/Megaparsec/Errors/Bundle.lean
@@ -27,7 +27,7 @@ private def makePEBfs [Printable β] [ToString E] [Streamable ℘] : ((String �
           | .trivial _     none _ => 1
           | .trivial _ (some x) _ => errorItemLength x
           | .fancy   _         xs =>
-            xs.foldl (fun acc e => max acc (errorFancyLength e)) 1
+            xs.fold (fun acc e _ => max acc (errorFancyLength e)) 1
         let rpshift := epos.column.pos - 1
         let pointerLen :=
           if rpshift + elen > sline.length

--- a/Megaparsec/Errors/StreamErrors.lean
+++ b/Megaparsec/Errors/StreamErrors.lean
@@ -37,24 +37,21 @@ def mergeErrors (e₁: ParseError β E)
         match (e₁, e₂) with
           | (ParseError.trivial s₁ u₁ p₁, .trivial _ u₂ p₂) =>
              match (u₁, u₂) with
-               | (.none, .none) => .trivial s₁ .none (p₁ ++ p₂)
-               | (.some x, .some y) => .trivial s₁ (.some (eiMax x y)) (p₁ ++ p₂)
-               | (.none, .some x) => .trivial s₁ (.some x) (p₁ ++ p₂)
-               | (.some x, .none)=> .trivial s₁ (.some x) (p₁ ++ p₂)
+               | (.none, .none) => .trivial s₁ .none $ mergeKeySetsAny p₁ p₂
+               | (.some x, .some y) => .trivial s₁ (.some (eiMax x y)) $ mergeKeySetsAny p₁ p₂
+               | (.none, .some x) => .trivial s₁ (.some x) $ mergeKeySetsAny p₁ p₂
+               | (.some x, .none)=> .trivial s₁ (.some x) $ mergeKeySetsAny p₁ p₂
           | (.fancy _ _, .trivial _ _ _) => e₁
           | (.trivial _ _ _, .fancy _ _) => e₂
-          | (.fancy s₁ x₁, .fancy _ x₂) => .fancy s₁ (x₁ ++ x₂)
+          | (.fancy s₁ x₁, .fancy _ x₂) => .fancy s₁ $ mergeKeySetsAny x₁ x₂
     | Ordering.gt => e₁
 
-instance : Append (ParseError β E) where
-  append := mergeErrors
-
-def toHints (streamPos : Nat) (e : ParseError α E) : Hints α :=
+def toHints (streamPos : Nat) (e : ParseError β E) : Hints β :=
   match e with
     | ParseError.fancy _ _ => []
     | ParseError.trivial errOffset _ ps =>
         if streamPos == errOffset
-           then (if List.isEmpty ps then [] else [ps])
+           then (if ps.isEmpty then [] else [ps.keys.toList])
            else []
 
 def refreshLastHint (h : Hints β) (m : Option (ErrorItem β)) : Hints β :=

--- a/Megaparsec/Parsec.lean
+++ b/Megaparsec/Parsec.lean
@@ -35,6 +35,8 @@ open Straume.Coco
 open Straume.Iterator (Iterable)
 open Straume.Iterator renaming Bijection → Iterable.Bijection
 
+section
+
 structure Consumed where
 structure Empty where
 
@@ -139,8 +141,10 @@ def longestMatch (s₀ : State β ℘ E) (s₁ : State β ℘ E) : State β ℘ 
 
 open StreamErrors in
 open Outcome in
-instance : Alternative (ParsecT m β ℘ E) where
-  failure := fun _ s _ _ _ eerr => eerr.2 (.trivial s.offset Option.none []) s
+instance [Ord β] : Alternative (ParsecT m β ℘ E) where
+  failure := fun _ s _ _ _ eerr =>
+    let empty : Std.RBMap (ErrorItem β) Unit compare := default
+    eerr.2 (.trivial s.offset .none empty) s
   orElse guess thunk :=
     fun xi s cok cerr eok eerr =>
       let fallback err ms :=
@@ -161,8 +165,9 @@ instance : Alternative (ParsecT m β ℘ E) where
 --         (thunk ()) xi s cok (cerr.1, nge cerr.2) (eok.1, ng) (eerr.1, nge eerr.2)
 --     guess xi s cok cerr eok (eerr.1, fallback)
 
-instance : Inhabited (ParsecT m β ℘ E γ) where
+instance [Ord β] : Inhabited (ParsecT m β ℘ E γ) where
   default := Alternative.failure
+
 
 ---=========================================================--
 ---================= IMPORTANT FUNCTIONS ===================--
@@ -214,6 +219,8 @@ def parseT (p : ParsecT m β ℘ E γ) (xs : ℘) [Monad m] :=
 
 def parse (p : Parsec β ℘ E γ) (xs : ℘) :=
   parseP p "" xs
+
+end
 
 def parsesT? (p : ParsecT m β ℘ E γ) (xs : ℘) [Monad m] :=
   parseT p xs >>= (pure ∘ Either.isRight)

--- a/Megaparsec/ParserState.lean
+++ b/Megaparsec/ParserState.lean
@@ -60,20 +60,20 @@ structure State (β ℘ E : Type u) where
 /- A result of evaluation of a particular parser. -/
 open Megaparsec.Errors.Result in
 structure Reply (β ℘ γ E : Type u) where
-  state    : @State β ℘ E
+  state    : State β ℘ E
   consumed : Bool
   result   : Result β γ E
 
-def longestMatch (s₁ : @State β ℘ E) (s₂ : @State β ℘ E) : @State β ℘ E :=
+def longestMatch (s₁ : State β ℘ E) (s₂ : State β ℘ E) : State β ℘ E :=
   match compare s₁.offset s₂.offset with
     | Ordering.lt => s₂
     | Ordering.eq => s₂
     | Ordering.gt => s₁
 
-private def defaultTabWidth : Nat := 2
+def defaultTabWidth : Nat := 2
 
 /- State smart constructor. -/
-def initialState (sourceName : String) (xs : ℘) : @State β ℘ E :=
+def initialState (sourceName : String) (xs : ℘) : State β ℘ E :=
   let sourcePos := initialSourcePos sourceName
   let posState := PosState.mk xs 0 sourcePos defaultTabWidth ""
   State.mk xs 0 posState []

--- a/Megaparsec/Pos.lean
+++ b/Megaparsec/Pos.lean
@@ -2,7 +2,7 @@ namespace Megaparsec.Pos
 
 structure Pos where
   pos : Nat
-  deriving Repr, DecidableEq
+  deriving Repr, DecidableEq, Ord
 
 instance : ToString Pos where
   toString x := s!"{x.pos}"

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -10,10 +10,10 @@ require LSpec from git
   "https://github.com/yatima-inc/LSpec.git" @ "9c9f3cc9f3148c1b2d6071a35e54e4c5392373b7"
 
 require YatimaStdLib from git
-  "https://github.com/yatima-inc/YatimaStdLib.lean.git" @ "876d29cb6f8011119a74712de7cb86280e408e3b"
+  "https://github.com/yatima-inc/YatimaStdLib.lean.git" @ "9270cda461d9b76a5ae5004ccb4f02428622d390"
 
 require Straume from git
-  "https://github.com/yatima-inc/straume/" @ "fa32bbbc9942c2339e5d363ef5af1e5af081470b"
+  "https://github.com/yatima-inc/straume/" @ "9429ac391b9ef4fb8df648d8873439bc7e30c3a0"
 
 @[defaultTarget]
 lean_exe megaparsec {


### PR DESCRIPTION
Problem: currently we use a list to store suggestions/hints/expected values for our parsing errors. This is simple, yet can lead to nonsensical duplicate errors. Example:

```lean
  let p  : Parsec Char String Unit String := string "yatima"
  let _ ← parseTestP (p <|> p <|> p) "Yatima"
```

results in:

```
  1:1:
  |
1 | Yatima
  | ^^^^^^
unexpected  "Yatima"
expecting  "yatima", "yatima", or "yatima"
```

Solution: switched to using RBMap instead of List.

Closes #11