### PR TITLE
[#37] Switch from Either to Except

### DIFF
--- a/Megaparsec/Parsec.lean
+++ b/Megaparsec/Parsec.lean
@@ -178,24 +178,24 @@ open Megaparsec.Errors.Bundle
 /- Extracts the end result from ParsecT run and presents it as a tuple under inner monad. -/
 def runParserT' {m : Type u → Type v} {β ℘ E γ : Type u}
                 (p : ParsecT m β ℘ E γ) (s₀ : State β ℘ E) [Monad m]
-                : m (State β ℘ E × (Either (ParseErrorBundle β ℘ E) γ)) := do
+                : m (State β ℘ E × (Except (ParseErrorBundle β ℘ E) γ)) := do
   let reply ← runParsecT p s₀
   let s₁ := reply.state
   pure $
     match reply.result with
     | .ok x =>
       match NEList.nonEmpty $ s₁.parseErrors with
-      | .none => (s₁, Either.right x)
-      | .some pes => (s₁, .left $ toBundle s₀ pes)
-    | .err e => (s₁, .left (toBundle s₀ $ List.toNEList e s₁.parseErrors))
+      | .none => (s₁, .ok x)
+      | .some pes => (s₁, .error $ toBundle s₀ pes)
+    | .err e => (s₁, .error (toBundle s₀ $ List.toNEList e s₁.parseErrors))
 
 def parseTestTP {m : Type → Type v} {β ℘ E : Type} {γ : Type}
                 (p : ParsecT m β ℘ E γ) (xs : ℘) (srcName := "(test run)") [ToString E] [Printable β] [ToString γ] [Monad m] [MonadLiftT m IO] [Streamable ℘]
-                : IO (Bool × Either Unit γ) := do
+                : IO (Bool × Except Unit γ) := do
   let reply ← liftM $ runParserT' p (initialState srcName xs)
   match reply.2 with
-  | .left e => IO.println e >>= fun _ => pure $ (false, Either.left ())
-  | .right y => IO.println y >>= fun _ => pure $ (true, Either.right y)
+  | .error e => IO.println e >>= fun _ => pure $ (false, .error ())
+  | .ok y => IO.println y >>= fun _ => pure $ (true, .ok y)
 
 /- Extracts the end result from Parsec run and presents it as a tuple as is (under Id monad). -/
 def runParserS (p : Parsec β ℘ E γ) (s₀ : State β ℘ E) :=
@@ -223,19 +223,19 @@ def parse (p : Parsec β ℘ E γ) (xs : ℘) :=
 end
 
 def parsesT? (p : ParsecT m β ℘ E γ) (xs : ℘) [Monad m] :=
-  parseT p xs >>= (pure ∘ Either.isRight)
+  parseT p xs >>= (pure ∘ Except.isOk)
 
 def parses? (p : Parsec β ℘ E γ) (xs : ℘) :=
-  Either.isRight $ parse p xs
+  Except.isOk $ parse p xs
 
 /- Test some parser polymorphically. -/
 def parseTestP (p : Parsec β ℘ E γ) [ToString γ] [Printable β] [ToString E]
-  (xs : ℘) [Streamable ℘] : IO (Bool × Either Unit γ) :=
+  (xs : ℘) [Streamable ℘] : IO (Bool × Except Unit γ) :=
   match parseP p "" xs with
-  | .left es => IO.println s!"{es}" >>= fun _ => pure $ (false, Either.left ())
-  | .right y => IO.println y >>= fun _ => pure $ (true, Either.right y)
+  | .error es => IO.println s!"{es}" >>= fun _ => pure $ (false, .error ())
+  | .ok y => IO.println y >>= fun _ => pure $ (true, .ok y)
 
 def parseTest (p : Parsec β ℘ E γ) [ToString γ] [Printable β] [ToString E] (xs : ℘) [Streamable ℘] : String :=
   match parseP p "" xs with
-  | .left es => s!"Err: {es}"
-  | .right y => s!"Ok: {y}"
+  | .error es => s!"Err: {es}"
+  | .ok y => s!"Ok: {y}"

--- a/Tests/IO.lean
+++ b/Tests/IO.lean
@@ -36,14 +36,11 @@ def main := do
     parseT (string "ab" *> string "cd" <* eol <* eof : PIO String) ("", h')
 
   lspecIO $
-    withExceptOk "file, manual newline: parsing successful"
-      (Either.either .error .ok fIO)
+    withExceptOk "file, manual newline: parsing successful" fIO
       (fun s => test "parsed out 'abcd'" $ s = "abcd") ++
 
-    withExceptOk "file, no newline: parsing successful"
-      (Either.either .error .ok fnlIO)
+    withExceptOk "file, no newline: parsing successful" fnlIO
       (fun s => test "parsed out 'abcd'" $ s = "abcd") ++
 
-    withExceptOk "file, newline combinator: parsing successful"
-      (Either.either .error .ok fIO')
+    withExceptOk "file, newline combinator: parsing successful" fIO'
       (fun s => test "parsed out 'cd'" $ s = "cd")

--- a/Tests/Lisp.lean
+++ b/Tests/Lisp.lean
@@ -13,15 +13,11 @@ open Megaparsec.Printable
 open Megaparsec.Streamable
 open LispParser
 
-private def toExcept : Either α β → Except α β
-  | .right x => .ok x
-  | .left e => .error e
-
 private def parseAndJoin (p : Parsec β ℘ E (List String)) (src : ℘)
                          [ToString E] [Printable β] [Streamable ℘] :=
   match parse p src with
-  | .right xs => String.join xs
-  | .left  es => s!"Error: {es}"
+  | .ok xs => String.join xs
+  | .error  es => s!"Error: {es}"
 
 def ignoreTest : TestSeq :=
   let commentSrc := "   ; hello, world!"
@@ -51,7 +47,7 @@ private def expectedA : Lisp := .string ("a", r' 1 4)
 
 private def mkLispTest (str : String) (expected : Lisp) : TestSeq :=
   group s!"{str}" $
-    withExceptOk "parsing successful" (toExcept $ parse lispParser str)
+    withExceptOk "parsing successful" (parse lispParser str)
     fun resulting => test "as expected" (resulting == expected)
 
 def lispTest : TestSeq :=

--- a/Tests/StateT.lean
+++ b/Tests/StateT.lean
@@ -30,11 +30,11 @@ def stateTest : TestSeq :=
     pure parsed
 
   withExceptError "StateT with failing parser: fails"
-    (Either.either .error .ok $ parse (StateT.run ptSO 1) sample)
+    (parse (StateT.run ptSO 1) sample)
     (fun _ => .done) ++
 
   withExceptOk "StateT parsing successful"
-    (Either.either .error .ok $ parse (StateT.run ptST 1) sample)
+    (parse (StateT.run ptST 1) sample)
     (fun (s, x) =>
       test "state is 42" (x = 42) $
       test "empty string parsed out" (s = "")


### PR DESCRIPTION
Problem: some time ago, we have made a decision to deprecate our custom `Either` datatype, defined in YatimaStdLib. We now want to follow through and switch to the built-in `Except` type with (mostly) the same semantics.

Solution: made the switch in Parsec and in tests.

Closes #37 