### PR TITLE
Problem: Some deps have `.git`, some don't

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -7,13 +7,13 @@ package Megaparsec
 lean_lib Megaparsec
 
 require LSpec from git
-  "https://github.com/yatima-inc/LSpec.git" @ "89798a6cb76b2b29469ff752af2fd8543b3a5515"
+  "https://github.com/yatima-inc/LSpec" @ "89798a6cb76b2b29469ff752af2fd8543b3a5515"
 
 require YatimaStdLib from git
   "https://github.com/yatima-inc/YatimaStdLib.lean" @ "f905b68f529de2af44cf6ea63489b7e3cd090050"
 
 require Straume from git
-  "https://github.com/yatima-inc/straume/" @ "849b7c7dc5eff27bf8cfe7e9e91d6195a7b964cb"
+  "https://github.com/yatima-inc/straume" @ "849b7c7dc5eff27bf8cfe7e9e91d6195a7b964cb"
 
 @[default_target]
 lean_exe megaparsec {

--- a/lean_packages/manifest.json
+++ b/lean_packages/manifest.json
@@ -1,6 +1,6 @@
 {"version": 2,
  "packages":
- [{"url": "https://github.com/yatima-inc/LSpec.git",
+ [{"url": "https://github.com/yatima-inc/LSpec",
    "rev": "89798a6cb76b2b29469ff752af2fd8543b3a5515",
    "name": "LSpec",
    "inputRev": "89798a6cb76b2b29469ff752af2fd8543b3a5515"},
@@ -8,7 +8,7 @@
    "rev": "f905b68f529de2af44cf6ea63489b7e3cd090050",
    "name": "YatimaStdLib",
    "inputRev": "f905b68f529de2af44cf6ea63489b7e3cd090050"},
-  {"url": "https://github.com/yatima-inc/straume/",
+  {"url": "https://github.com/yatima-inc/straume",
    "rev": "849b7c7dc5eff27bf8cfe7e9e91d6195a7b964cb",
    "name": "Straume",
    "inputRev": "849b7c7dc5eff27bf8cfe7e9e91d6195a7b964cb"},


### PR DESCRIPTION
Solution:

 - Make them consistent!

I think we should have deps without `.git` elsewhere too, because `.git` bit is not a principal thing that is required for git repos.