### PR TITLE
Updated Megaparsec to work with new definition of NEList

### DIFF
--- a/Megaparsec/Errors.lean
+++ b/Megaparsec/Errors.lean
@@ -48,7 +48,7 @@ instance [ToString β] : ToString (ErrorItem β) where
   | .tokens t => match t with
     | ⟦x⟧ => s!"{x}"
     | x :| xs => "\"" ++
-      NEList.foldl (fun acc token => s!"{acc}{token}") (toString x) xs ++ "\""
+      xs.foldl (fun acc token => s!"{acc}{token}") (toString x) ++ "\""
 
 
 --                    TODO: make this a set

--- a/Megaparsec/Errors/ParseError.lean
+++ b/Megaparsec/Errors/ParseError.lean
@@ -59,9 +59,9 @@ variable {E : Type u} [ToString E]
 
 def NEList.spanToLast (ne : NEList α) : (List α × α) :=
   let rec go
-    | ⟦x⟧, acc => (acc, x)
-    | x :| xs, acc => go xs (x :: acc)
-  go ne []
+    | x, [], acc => (acc, x)
+    | x, y :: ys, acc => go y ys (x :: acc)
+  go ne.head ne.tail []
 
 -- Print a pretty list where items are separated with commas and the word
 -- “or” according to the rules of English punctuation.

--- a/Megaparsec/MonadParsec.lean
+++ b/Megaparsec/MonadParsec.lean
@@ -123,7 +123,7 @@ universe v
 private def hs₀ (β ℘ E : Type u) (_ : State β ℘ E) (_ : ParseError β E) : Hints β := []
 private def hs' (β ℘ E : Type u) (s' : State β ℘ E) (e : ParseError β E) := toHints (State.offset s') e
 private def nelstr (x : Char) (xs : String) := match NEList.nonEmptyString xs with
-  | .some xs' => NEList.cons x xs'
+  | .some xs' => NEList.cons x xs'.toList
   | .none => NEList.uno x
 
 def fixs (c : χ) : Except ε (α × τ) → (Except ε α) × χ

--- a/Megaparsec/Printable.lean
+++ b/Megaparsec/Printable.lean
@@ -86,11 +86,10 @@ instance : Printable Char where
 instance : Printable String where
   showTokens nl :=
     let showStr str := (stringPretty <$> NEList.nonEmptyString str).getD ""
-    let rec go xs := match xs with
-      | ⟦x⟧ => [showStr x]
-      | "" :| xs => go xs
-      | x  :| xs => showStr x :: go xs
-    match String.join $ go nl with
+    let rec go x xs := match xs with
+      | [] => [showStr x]
+      | y :: ys => if x.isEmpty then go y ys else showStr x :: go y ys
+    match String.join $ go nl.head nl.tail with
     | "" => "empty string"
     | joined => s!"\"{joined}\""
 
@@ -101,7 +100,7 @@ open ByteArray in
 instance : Printable Bit where
   showTokens
     | ⟦b⟧ => s!"'{b}'"
-    | nl => let rec go xs := match xs with
-      | ⟦b⟧ => [toString b]
-      | b :| bs => toString b :: go bs
-      s!"\"{String.join $ go nl}\""
+    | nl => let rec go b xs := match xs with
+      | [] => [toString b]
+      | y :: ys => toString b :: go y ys
+      s!"\"{String.join $ go nl.head nl.tail}\""

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -4,9 +4,9 @@
  [{"git":
    {"url": "https://github.com/yatima-inc/YatimaStdLib.lean",
     "subDir?": null,
-    "rev": "649368d593f292227ab39b9fd08f6a448770dca8",
+    "rev": "b3084d5fb020975555dabe507e6a4db659b0733d",
     "name": "YatimaStdLib",
-    "inputRev?": "649368d593f292227ab39b9fd08f6a448770dca8"}},
+    "inputRev?": "b3084d5fb020975555dabe507e6a4db659b0733d"}},
   {"git":
    {"url": "https://github.com/yatima-inc/straume",
     "subDir?": null,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -10,7 +10,7 @@ require LSpec from git
   "https://github.com/yatima-inc/LSpec" @ "88f7d23e56a061d32c7173cea5befa4b2c248b41"
 
 require YatimaStdLib from git
-  "https://github.com/yatima-inc/YatimaStdLib.lean" @ "649368d593f292227ab39b9fd08f6a448770dca8"
+  "https://github.com/yatima-inc/YatimaStdLib.lean" @ "b3084d5fb020975555dabe507e6a4db659b0733d"
 
 require Straume from git
   "https://github.com/yatima-inc/straume" @ "9597873f0b18a9e97b7315fb84968c55d09a6112"


### PR DESCRIPTION
The old definition of `NEList` was a recursive inductive,
```lean
inductive NEList (α : Type _)
  | uno  : α → NEList α
  | cons : α → NEList α → NEList α
```
meaning that recursion could be used directly. However, it was inefficient, in that `List` and `NEList` could only be converted in O(n), furthermore their memory layouts were different. With the new definition
```lean
structure NEList (α : Type u) where
  head : α
  tail : List α
```
the datatype becomes non-recursive, though it will give you O(1) conversion, with the same layout in memory. It also has the added benefit of being able to reuse `List` definitions in their `NEList` counterpart.
However, being non-recursive, well-founded recursion can only be used indirectly, by doing recursion on the tail of the `NEList`. So for instance, something like
```lean
def sum : NEList Nat → Nat
  | .uno a => a
  | .cons a as => a + sum as
```
has to be defined as
```lean
def sum (as : NEList Nat) : Nat :=
  let rec go
    | a, [] => a
    | a, b :: bs => a + go b bs
  go as.head as.tail
```
which admittedly is less pretty. Of course, in this case we could use `foldl`/`foldr` instead. However, this particular recursion pattern is not exactly the same as `foldl`/`foldr`, but something unique to `NEList`.

This brings the question of implementation vs interface. Should we define our datatypes as abstract interfaces, where we could change the underlying implementation without breaking any code that only uses the interface? Should the two definitions of NEList actually be considered different?