### PR TITLE
Problem: NEList breaking change unincorporated

### DIFF
--- a/Megaparsec/Char.lean
+++ b/Megaparsec/Char.lean
@@ -20,7 +20,7 @@ variable {m : Type → Type v} {℘ E α : Type}
          [Alternative m] [SeqLeft m] [SeqRight m]
 
 def char' (x : Char) :=
-  choice (i := im) [single (i := im) x.toLower, single (i := im) x.toUpper]
+  choice (_i := im) [single (i := im) x.toLower, single (i := im) x.toUpper]
 
 def tab := single (i := im) '\t'
 
@@ -28,10 +28,10 @@ def newline := single (i := im) '\n'
 
 def cr := single (i := im) '\r'
 
-def crlf := attempt (i := im) $
+def crlf := attempt (_i := im) $
   newline (im := im) *> cr (im := im) *> pure "\r\n"
 
-def eol := label (i := im)
+def eol := label (_i := im)
   "end of line" $
   (newline (im := im) *> pure "\n") <|> crlf (im := im)
 

--- a/Megaparsec/Common.lean
+++ b/Megaparsec/Common.lean
@@ -26,10 +26,10 @@ universe u
 section
 
 def single {m : Type u → Type v} {℘ α E β : Type u} [i : MonadParsec m ℘ α E β] [BEq β] (x : β) : m β :=
-  MonadParsec.token ℘ α E (fun y => if x == y then .some x else .none) [ErrorItem.tokens $ NEList.uno x]
+  MonadParsec.token ℘ α E (fun y => if x == y then .some x else .none) [ErrorItem.tokens $ NEList.mk (x :: []) (by simp)]
 
 -- TODO: case-insensitive version
-def string {m : Type u → Type v} {℘ α E β : Type u} [i : MonadParsec m ℘ α E β] [BEq α] (x : α) : m α :=
+def string {m : Type u → Type v} {℘ α E β : Type u} [_i : MonadParsec m ℘ α E β] [BEq α] (x : α) : m α :=
   MonadParsec.tokens ℘ E β (BEq.beq) x
 
 instance : Ord PUnit where
@@ -142,7 +142,7 @@ def choice' {m : Type → Type v} {β ℘ E γ : Type} (ps : List (ParsecT m β 
   List.foldr (fun a b => a <|> b) Alternative.failure ps
 
 /- m-polymorphic choice -/
-def choice {m : Type → Type v} {℘ α E β : Type} {γ : Type} [i : MonadParsec m ℘ α E β] [Alternative m]
+def choice {m : Type → Type v} {℘ α E β : Type} {γ : Type} [_i : MonadParsec m ℘ α E β] [Alternative m]
   (ps : List (m γ))
   : m γ :=
   List.foldr (fun a b => a <|> b) Alternative.failure ps

--- a/Megaparsec/Errors.lean
+++ b/Megaparsec/Errors.lean
@@ -45,10 +45,9 @@ instance [ToString β] : ToString (ErrorItem β) where
   toString
   | .eof => "end of input"
   | .label t => String.mk t.toList
-  | .tokens t => match t with
-    | ⟦x⟧ => s!"{x}"
-    | x :| xs => "\"" ++
-      xs.foldl (fun acc token => s!"{acc}{token}") (toString x) ++ "\""
+  | .tokens t =>
+    "\"" ++
+      t.data.foldl (fun acc token => s!"{acc}{token}") (toString t) ++ "\""
 
 
 --                    TODO: make this a set

--- a/Megaparsec/Errors/ParseError.lean
+++ b/Megaparsec/Errors/ParseError.lean
@@ -65,10 +65,12 @@ def NEList.spanToLast (ne : NEList α) : (List α × α) :=
 
 -- Print a pretty list where items are separated with commas and the word
 -- “or” according to the rules of English punctuation.
-def orList : NEList String → String
-  | ⟦x⟧ => x
-  | ⟦x,y⟧ => s!"{x} or {y}"
-  | xs => let (lxs, last) := NEList.spanToLast xs
+def orList (xs : NEList String) : String :=
+  match xs.data with
+  | [] => unreachable!
+  | [x] => x
+  | [x, y] => s!"{x} or {y}"
+  | _ => let (lxs, last) := NEList.spanToLast xs
     String.intercalate ", " lxs ++ ", or " ++ last
 
 -- Transform a list of error messages into their textual representation.

--- a/Megaparsec/Lisp.lean
+++ b/Megaparsec/Lisp.lean
@@ -55,16 +55,16 @@ variable {m : Type → Type v} {℘ : Type}
 
 def quoteAnyChar := single (i := im) '\\' *> anySingle (i := im)
 
-def stringP := label (i := im) "string" $ do
+def stringP := label (_i := im) "string" $ do
   let (str : String) ←
     between (im := im) '"' '"' $
       String.mk <$> (manyP m ℘ Char Unit $ quoteAnyChar <|> noneOf (i := im) "\\\"".data)
   pure $ fun r => Lisp.string (str, r)
 
-def commentP := label (i := im) "comment" $ do
+def commentP := label (_i := im) "comment" $ do
   discard $ single (i := im) ';'
   let comment ← manyP m ℘ Char Unit $ noneOf (i := im) "\r\n".data
-  discard $ Megaparsec.Char.eol (im := im) <|> (eof (i := im) *> pure "")
+  discard $ Megaparsec.Char.eol (im := im) <|> (eof (_i := im) *> pure "")
   pure $ s!";{String.mk comment}"
 
 def ignore :=
@@ -73,17 +73,17 @@ def ignore :=
 mutual
 
   partial def lispParser : ParsecT m Char ℘ Unit Lisp :=
-    withRange (i := im) lispExprP
+    withRange (_i := im) lispExprP
 
   partial def listP : ParsecT m Char ℘ Unit (Range → Lisp) :=
-    label (i := im) "list" $ do
+    label (_i := im) "list" $ do
     between (im := im) '(' ')' $ do
       let ys ← sepEndByP m ℘ Char Unit lispParser ignore
       pure $ fun r => Lisp.list (ys, r)
 
   partial def lispExprP : ParsecT m Char ℘ Unit (Range → Lisp) :=
     choice' [
-      attempt (i := im) stringP,
+      attempt (_i := im) stringP,
       listP
     ]
 

--- a/Megaparsec/MonadParsec.lean
+++ b/Megaparsec/MonadParsec.lean
@@ -123,8 +123,8 @@ universe v
 private def hs₀ (β ℘ E : Type u) (_ : State β ℘ E) (_ : ParseError β E) : Hints β := []
 private def hs' (β ℘ E : Type u) (s' : State β ℘ E) (e : ParseError β E) := toHints (State.offset s') e
 private def nelstr (x : Char) (xs : String) := match NEList.nonEmptyString xs with
-  | .some xs' => NEList.cons x xs'.toList
-  | .none => NEList.uno x
+  | .some xs' => NEList.mk (x :: xs'.data) (by simp)
+  | .none => NEList.mk (x :: []) (by simp)
 
 def fixs (c : χ) : Except ε (α × τ) → (Except ε α) × χ
   | .error  e  => (.error  e, c)
@@ -168,7 +168,7 @@ instance theInstance {m : Type u → Type v} {α β ℘ E : Type u} [Streamable 
   notFollowedBy p := fun xi s _ _ eok eerr => do
     let o := s.offset
     let y : (Chunk β × ℘) ← Straume.take1 α s.input
-    let c2e := ErrorItem.tokens ∘ NEList.uno
+    let c2e := ErrorItem.tokens ∘ (fun x => NEList.mk (x :: []) (by simp))
     let subject : ErrorItem β := match y.1 with
     -- TODO: Here and in many other places, we have two branches that are the same because Parsec doesn't care about .fin vs .cont
     -- TODO: Perhaps, we should use Terminable and extract values
@@ -194,7 +194,7 @@ instance theInstance {m : Type u → Type v} {α β ℘ E : Type u} [Streamable 
   eof := fun _ s _ _ eok eerr => do
       let y : (Chunk β × ℘) ← Straume.take1 α s.input
       let singleton : RBSet (ErrorItem β) compare := .single .eof
-      let err c := eerr.2 (.trivial s.offset (.some $ ErrorItem.tokens $ NEList.uno c) singleton) s
+      let err c := eerr.2 (.trivial s.offset (.some $ ErrorItem.tokens $ NEList.mk (c :: []) (by simp) ) singleton) s
       match y.1 with
       | .nil => eok.2 PUnit.unit s []
       | .cont c => err c
@@ -207,7 +207,7 @@ instance theInstance {m : Type u → Type v} {α β ℘ E : Type u} [Streamable 
     let set := .ofList errorCtx compare
     let test c := match ρ c with
     | .none =>
-      eerr.2 (.trivial s.offset (.some $ ErrorItem.tokens $ NEList.uno c) set) s
+      eerr.2 (.trivial s.offset (.some $ ErrorItem.tokens $ NEList.mk (c :: []) (by simp)) set) s
     | .some y' =>
       let offset' := s.offset + 1
       cok.2 y' {s with offset := offset', input := y.2, posState := reachOffsetNoLine offset' s.posState } []
@@ -276,7 +276,7 @@ instance theInstance {m : Type u → Type v} {α β ℘ E : Type u} [Streamable 
       let n := Iterable.length cs
       if (n == 0) then
         let yb : (Chunk β × ℘) ← (Straume.take1 α s.input)
-        let got c := .some (ErrorItem.tokens $ NEList.uno c)
+        let got c := .some (ErrorItem.tokens $ NEList.mk (c :: []) (by simp))
         match yb.1 with
         | .nil =>
           eerr.2 (.trivial s.offset (.some ErrorItem.eof) want) s
@@ -377,7 +377,7 @@ instance statetInstance
   getParserState := liftM $ mₚ.getParserState
   updateParserState φ := liftM $ mₚ.updateParserState φ
 
-def withRange (α : Type u) (p : ParsecT m β ℘ E (Range → γ)) [i : MonadParsec (ParsecT m β ℘ E) ℘ α E β] : ParsecT m β ℘ E γ := do
+def withRange (α : Type u) (p : ParsecT m β ℘ E (Range → γ)) [_i : MonadParsec (ParsecT m β ℘ E) ℘ α E β] : ParsecT m β ℘ E γ := do
   let s₀ : State β ℘ E ← MonadParsec.getParserState α
   let first := s₀.posState.sourcePos
   let go ← p
@@ -397,7 +397,7 @@ def parseError {m: Type u → Type v} {℘ α E β: Type u} [MonadParsec m ℘ �
   : Megaparsec.Errors.ParseError.ParseError β E → m γ :=
   MonadParsec.MonadParsec.parseError ℘ α
 
-def label {m: Type u → Type v} {℘ α E β: Type u} [i : MonadParsec.MonadParsec m ℘ α E β] {γ : Type u}
+def label {m: Type u → Type v} {℘ α E β: Type u} [_i : MonadParsec.MonadParsec m ℘ α E β] {γ : Type u}
   : String → m γ → m γ :=
   MonadParsec.MonadParsec.label ℘ α E β
 
@@ -405,7 +405,7 @@ def hidden {m: Type u → Type v} {℘ α E β: Type u} [MonadParsec.MonadParsec
   : m γ → m γ :=
   MonadParsec.MonadParsec.hidden ℘ α E β
 
-def attempt {m: Type u → Type v} {℘ α E β: Type u} [i : MonadParsec.MonadParsec m ℘ α E β] {γ : Type u}
+def attempt {m: Type u → Type v} {℘ α E β: Type u} [_i : MonadParsec.MonadParsec m ℘ α E β] {γ : Type u}
   : m γ → m γ :=
   MonadParsec.MonadParsec.attempt ℘ α E β
 
@@ -425,7 +425,7 @@ def observing {m: Type u → Type v} {℘ α E β: Type u} [MonadParsec.MonadPar
   : m γ → m (Except (Megaparsec.Errors.ParseError.ParseError β E) γ) :=
   MonadParsec.MonadParsec.observing ℘ α
 
-def eof {m: Type u → Type v} {℘ α E β: Type u} [i : MonadParsec.MonadParsec m ℘ α E β] : m PUnit :=
+def eof {m: Type u → Type v} {℘ α E β: Type u} [_i : MonadParsec.MonadParsec m ℘ α E β] : m PUnit :=
   MonadParsec.MonadParsec.eof ℘ α E β
 
 def token {m: Type u → Type v} {℘ α E β: Type u} [MonadParsec.MonadParsec m ℘ α E β]

--- a/Megaparsec/Printable.lean
+++ b/Megaparsec/Printable.lean
@@ -63,14 +63,8 @@ private def charPretty : Char → String
   | ' ' => "space"
   | ch  => (charPretty' ch).getD $ s!"'{ch}'"
 
-private def stringPretty : NEList Char → String
-  | ⟦x⟧ => charPretty x
-  | ⟦'\r','\n'⟧ => "crlf newline"
-  | xs =>
-    let f c := match charPretty' c with
-      | .none => s!"{c}"
-      | .some pretty => s!"<{pretty}>"
-    s!"\"{String.join $ f <$> xs.toList}\""
+private def stringPretty : (NEList Char) → String :=
+  String.join ∘ (List.map charPretty) ∘ NEList.data
 
 --===========================================================--
 --=================== PRINTABLE INSTANCES ===================--
@@ -96,11 +90,9 @@ instance : Printable String where
 instance : Printable UInt8 where
   showTokens := stringPretty ∘ Functor.map (fun i => Char.ofNat $ i.toNat)
 
-open ByteArray in
 instance : Printable Bit where
-  showTokens
-    | ⟦b⟧ => s!"'{b}'"
-    | nl => let rec go b xs := match xs with
+  showTokens nl :=
+    let rec go b xs := match xs with
       | [] => [toString b]
       | y :: ys => toString b :: go y ys
-      s!"\"{String.join $ go nl.head nl.tail}\""
+    s!"\"{String.join $ go nl.head nl.tail}\""

--- a/Tests/Parsec.lean
+++ b/Tests/Parsec.lean
@@ -31,9 +31,9 @@ def duplicateErrorsTest : TestSeq :=
     withExceptError "parsing fails"
       (parse (p <|> p <|> p') "Yatima")
       fun errors =>
-        let es := match errors.errors with
-          | ⟦.trivial _ _ exs⟧ => exs.toList
-          | _ => [] -- impossible case for further testing
+        let es := match errors.errors.data with
+        | (.trivial _ _ exs) :: [] => exs.toList
+        | _ => [] -- impossible case for further testing
         let shouldBe := [
           ErrorItem.tokens (List.toNEList 'y' "atima".data),
           ErrorItem.tokens (List.toNEList 'y' "atima!".data)

--- a/Tests/StateT.lean
+++ b/Tests/StateT.lean
@@ -18,14 +18,14 @@ def stateTest : TestSeq :=
 
   let ptSO : StateT Nat (Parsec Char String Unit) String := do
     let x0 ← MonadStateOf.get
-    let fail ← string (i := statetInstance) "fail me"
+    let fail ← string (_i := statetInstance) "fail me"
     MonadStateOf.set $ x0 + 41
     pure fail
 
   let ptST : StateT Nat (Parsec Char String Unit) String := do
     MonadStateOf.set $ 1
     let x0 ← StateT.get
-    let parsed ← string (i := statetInstance) "fail me" <|> pure ""
+    let parsed ← string (_i := statetInstance) "fail me" <|> pure ""
     MonadStateOf.set $ x0 + 41
     pure parsed
 

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -4,15 +4,15 @@
  [{"git":
    {"url": "https://github.com/yatima-inc/YatimaStdLib.lean",
     "subDir?": null,
-    "rev": "b3084d5fb020975555dabe507e6a4db659b0733d",
+    "rev": "856a4e605bc55e242202459871cdcca0b4ba857e",
     "name": "YatimaStdLib",
-    "inputRev?": "b3084d5fb020975555dabe507e6a4db659b0733d"}},
+    "inputRev?": "856a4e605bc55e242202459871cdcca0b4ba857e"}},
   {"git":
    {"url": "https://github.com/yatima-inc/straume",
     "subDir?": null,
-    "rev": "9597873f0b18a9e97b7315fb84968c55d09a6112",
+    "rev": "b242267483bf0ff9368609f40e57c001e337d565",
     "name": "Straume",
-    "inputRev?": "9597873f0b18a9e97b7315fb84968c55d09a6112"}},
+    "inputRev?": "b242267483bf0ff9368609f40e57c001e337d565"}},
   {"git":
    {"url": "https://github.com/yatima-inc/LSpec",
     "subDir?": null,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -10,10 +10,10 @@ require LSpec from git
   "https://github.com/yatima-inc/LSpec" @ "88f7d23e56a061d32c7173cea5befa4b2c248b41"
 
 require YatimaStdLib from git
-  "https://github.com/yatima-inc/YatimaStdLib.lean" @ "b3084d5fb020975555dabe507e6a4db659b0733d"
+  "https://github.com/yatima-inc/YatimaStdLib.lean" @ "856a4e605bc55e242202459871cdcca0b4ba857e"
 
 require Straume from git
-  "https://github.com/yatima-inc/straume" @ "9597873f0b18a9e97b7315fb84968c55d09a6112"
+  "https://github.com/yatima-inc/straume" @ "b242267483bf0ff9368609f40e57c001e337d565"
 
 @[default_target]
 lean_exe megaparsec {


### PR DESCRIPTION
Solution:

 - Incorporate it, but see #47 for less verbosity
 - While at it, fix unused variables warnings for named instances
 - Update manual instance resolution to use the underscored instance variables


TESTS PASS!

* * *

```
Mon Jan 23 21:46:46:761550800 sweater@conflagrate ~/github/Megaparsec.lean (cognivore/bump-nelist) 
λ lego
Welcome to Megaparsec.lean!
Usage examples are available in the ./Examples directory,
as well as in the test suite.
Building Tests.Parsec
Building Tests.IO
Building Tests.StateT
Building Tests.Lisp
Running ./build/bin/Tests-Parsec
duplicate errors:
  ✓ parsing fails
  ✓ only one parse error
  ✓ two expected values, not three
✓ eof: parsing successful
given string: successful parsers:
  ✓ yatima: parsing successful
  ✓ parsed out 'yatima'
  ✓ parsing 'yatima' from 'yatimaaaa!': parsing successful
  ✓ leftover string is 'aaa!'
  ✓ parsing 'yat', then 'ima' from 'yatima!': parsing successful
given string: failing parsers:
  ✓ yatimA: parsing fails
  ✓ parsing 'yat', then 'ima' from 'yatimA!': parsing fails
Char.lean combinators:
  ✓ char' is case-insensitive: parsing successful
  ✓ parsed out 'y'
  ✓ eol: parsing successful
  ✓ parsed out newline
option combinator:
  ✓ none: parsing successful
  ✓ none
  ✓ raw some: parsing successful
  ✓ some
  ✓ some following none: parsing successful
  ✓ some
  ✓ holds 'hellraiser'
  ✓ some following some: parsing successful
  ✓ some
  ✓ holds 'hellraiser'
some' and many' combinators:
  ✓ many' on empty string: parsing successful
  ✓ result is empty list
  ✓ many' on matching string: parsing successful
  ✓ result is two reads
  ✓ some' on empty string: parsing fails
  ✓ some' on matching string: parsing successful
  ✓ result is two reads
sepEndBy1' combinator:
  ✓ parsing successful
  ✓ result is two reads
simple parsing:
  ✓ "3 2 1": parsing successful
  ✓ parsed out 3, 2, 1
  ✓ "5|": parsing successful
  ✓ parsed out 5
  ✓ "5": parsing fails
  ✓ "55|": parsing fails

Running ./build/bin/Tests-IO
✓ file, manual newline: parsing successful
✓ parsed out 'abcd'
✓ file, no newline: parsing successful
✓ parsed out 'abcd'
✓ file, newline combinator: parsing successful
✓ parsed out 'cd'

Running ./build/bin/Tests-StateT
✓ StateT with failing parser: fails
✓ StateT parsing successful
✓ state is 42
✓ empty string parsed out

Running ./build/bin/Tests-Lisp
ignore:
  ✓ all spaces
  ✓ comment
  ✓ leading
lisp parsing:
"a" ;:
    ✓ parsing successful
    ✓ as expected
("hello" ("beautiful" "world")) ; ())(lol n1 bug ))()):
    ✓ parsing successful
    ✓ as expected

All tests passed!
```