### PR TITLE
Problem: NEList breaking change unincorporated

### DIFF
--- a/Megaparsec/Char.lean
+++ b/Megaparsec/Char.lean
@@ -20,7 +20,7 @@ variable {m : Type → Type v} {℘ E α : Type}
          [Alternative m] [SeqLeft m] [SeqRight m]
 
 def char' (x : Char) :=
-  choice (i := im) [single (i := im) x.toLower, single (i := im) x.toUpper]
+  choice (_i := im) [single (i := im) x.toLower, single (i := im) x.toUpper]
 
 def tab := single (i := im) '\t'
 
@@ -28,10 +28,10 @@ def newline := single (i := im) '\n'
 
 def cr := single (i := im) '\r'
 
-def crlf := attempt (i := im) $
+def crlf := attempt (_i := im) $
   newline (im := im) *> cr (im := im) *> pure "\r\n"
 
-def eol := label (i := im)
+def eol := label (_i := im)
   "end of line" $
   (newline (im := im) *> pure "\n") <|> crlf (im := im)
 

--- a/Megaparsec/Common.lean
+++ b/Megaparsec/Common.lean
@@ -26,10 +26,10 @@ universe u
 section
 
 def single {m : Type u → Type v} {℘ α E β : Type u} [i : MonadParsec m ℘ α E β] [BEq β] (x : β) : m β :=
-  MonadParsec.token ℘ α E (fun y => if x == y then .some x else .none) [ErrorItem.tokens $ NEList.uno x]
+  MonadParsec.token ℘ α E (fun y => if x == y then .some x else .none) [ErrorItem.tokens $ NEList.mk [x] $ by simp]
 
 -- TODO: case-insensitive version
-def string {m : Type u → Type v} {℘ α E β : Type u} [i : MonadParsec m ℘ α E β] [BEq α] (x : α) : m α :=
+def string {m : Type u → Type v} {℘ α E β : Type u} [_i : MonadParsec m ℘ α E β] [BEq α] (x : α) : m α :=
   MonadParsec.tokens ℘ E β (BEq.beq) x
 
 instance : Ord PUnit where
@@ -142,7 +142,7 @@ def choice' {m : Type → Type v} {β ℘ E γ : Type} (ps : List (ParsecT m β 
   List.foldr (fun a b => a <|> b) Alternative.failure ps
 
 /- m-polymorphic choice -/
-def choice {m : Type → Type v} {℘ α E β : Type} {γ : Type} [i : MonadParsec m ℘ α E β] [Alternative m]
+def choice {m : Type → Type v} {℘ α E β : Type} {γ : Type} [_i : MonadParsec m ℘ α E β] [Alternative m]
   (ps : List (m γ))
   : m γ :=
   List.foldr (fun a b => a <|> b) Alternative.failure ps

--- a/Megaparsec/Errors.lean
+++ b/Megaparsec/Errors.lean
@@ -46,8 +46,8 @@ instance [ToString β] : ToString (ErrorItem β) where
   | .eof => "end of input"
   | .label t => String.mk t.toList
   | .tokens t => match t with
-    | ⟦x⟧ => s!"{x}"
-    | x :| xs => "\"" ++
+    | ⟨ [x], _ ⟩ => s!"{x}"
+    | ⟨ x :: xs, _ ⟩ => "\"" ++
       xs.foldl (fun acc token => s!"{acc}{token}") (toString x) ++ "\""
 
 

--- a/Megaparsec/Errors/ParseError.lean
+++ b/Megaparsec/Errors/ParseError.lean
@@ -66,8 +66,8 @@ def NEList.spanToLast (ne : NEList α) : (List α × α) :=
 -- Print a pretty list where items are separated with commas and the word
 -- “or” according to the rules of English punctuation.
 def orList : NEList String → String
-  | ⟦x⟧ => x
-  | ⟦x,y⟧ => s!"{x} or {y}"
+  | ⟨ [x], _ ⟩ => x
+  | ⟨ [x,y], _ ⟩ => s!"{x} or {y}"
   | xs => let (lxs, last) := NEList.spanToLast xs
     String.intercalate ", " lxs ++ ", or " ++ last
 

--- a/Megaparsec/Lisp.lean
+++ b/Megaparsec/Lisp.lean
@@ -55,16 +55,16 @@ variable {m : Type → Type v} {℘ : Type}
 
 def quoteAnyChar := single (i := im) '\\' *> anySingle (i := im)
 
-def stringP := label (i := im) "string" $ do
+def stringP := label (_i := im) "string" $ do
   let (str : String) ←
     between (im := im) '"' '"' $
       String.mk <$> (manyP m ℘ Char Unit $ quoteAnyChar <|> noneOf (i := im) "\\\"".data)
   pure $ fun r => Lisp.string (str, r)
 
-def commentP := label (i := im) "comment" $ do
+def commentP := label (_i := im) "comment" $ do
   discard $ single (i := im) ';'
   let comment ← manyP m ℘ Char Unit $ noneOf (i := im) "\r\n".data
-  discard $ Megaparsec.Char.eol (im := im) <|> (eof (i := im) *> pure "")
+  discard $ Megaparsec.Char.eol (im := im) <|> (eof (_i := im) *> pure "")
   pure $ s!";{String.mk comment}"
 
 def ignore :=
@@ -73,17 +73,17 @@ def ignore :=
 mutual
 
   partial def lispParser : ParsecT m Char ℘ Unit Lisp :=
-    withRange (i := im) lispExprP
+    withRange (_i := im) lispExprP
 
   partial def listP : ParsecT m Char ℘ Unit (Range → Lisp) :=
-    label (i := im) "list" $ do
+    label (_i := im) "list" $ do
     between (im := im) '(' ')' $ do
       let ys ← sepEndByP m ℘ Char Unit lispParser ignore
       pure $ fun r => Lisp.list (ys, r)
 
   partial def lispExprP : ParsecT m Char ℘ Unit (Range → Lisp) :=
     choice' [
-      attempt (i := im) stringP,
+      attempt (_i := im) stringP,
       listP
     ]
 

--- a/Megaparsec/MonadParsec.lean
+++ b/Megaparsec/MonadParsec.lean
@@ -123,8 +123,8 @@ universe v
 private def hs₀ (β ℘ E : Type u) (_ : State β ℘ E) (_ : ParseError β E) : Hints β := []
 private def hs' (β ℘ E : Type u) (s' : State β ℘ E) (e : ParseError β E) := toHints (State.offset s') e
 private def nelstr (x : Char) (xs : String) := match NEList.nonEmptyString xs with
-  | .some xs' => NEList.cons x xs'.toList
-  | .none => NEList.uno x
+  | .some xs' => NEList.mk (x :: xs'.toList) (by simp)
+  | .none => NEList.mk [x] (by simp)
 
 def fixs (c : χ) : Except ε (α × τ) → (Except ε α) × χ
   | .error  e  => (.error  e, c)
@@ -168,7 +168,7 @@ instance theInstance {m : Type u → Type v} {α β ℘ E : Type u} [Streamable 
   notFollowedBy p := fun xi s _ _ eok eerr => do
     let o := s.offset
     let y : (Chunk β × ℘) ← Straume.take1 α s.input
-    let c2e := ErrorItem.tokens ∘ NEList.uno
+    let c2e x := ErrorItem.tokens ∘ NEList.mk [x] $ by simp
     let subject : ErrorItem β := match y.1 with
     -- TODO: Here and in many other places, we have two branches that are the same because Parsec doesn't care about .fin vs .cont
     -- TODO: Perhaps, we should use Terminable and extract values
@@ -194,7 +194,7 @@ instance theInstance {m : Type u → Type v} {α β ℘ E : Type u} [Streamable 
   eof := fun _ s _ _ eok eerr => do
       let y : (Chunk β × ℘) ← Straume.take1 α s.input
       let singleton : RBSet (ErrorItem β) compare := .single .eof
-      let err c := eerr.2 (.trivial s.offset (.some $ ErrorItem.tokens $ NEList.uno c) singleton) s
+      let err c := eerr.2 (.trivial s.offset (.some $ ErrorItem.tokens $ NEList.mk [c] $ by simp) singleton) s
       match y.1 with
       | .nil => eok.2 PUnit.unit s []
       | .cont c => err c
@@ -207,7 +207,7 @@ instance theInstance {m : Type u → Type v} {α β ℘ E : Type u} [Streamable 
     let set := .ofList errorCtx compare
     let test c := match ρ c with
     | .none =>
-      eerr.2 (.trivial s.offset (.some $ ErrorItem.tokens $ NEList.uno c) set) s
+      eerr.2 (.trivial s.offset (.some $ ErrorItem.tokens $ NEList.mk [c] $ by simp) set) s
     | .some y' =>
       let offset' := s.offset + 1
       cok.2 y' {s with offset := offset', input := y.2, posState := reachOffsetNoLine offset' s.posState } []
@@ -276,7 +276,7 @@ instance theInstance {m : Type u → Type v} {α β ℘ E : Type u} [Streamable 
       let n := Iterable.length cs
       if (n == 0) then
         let yb : (Chunk β × ℘) ← (Straume.take1 α s.input)
-        let got c := .some (ErrorItem.tokens $ NEList.uno c)
+        let got c := .some (ErrorItem.tokens $ NEList.mk [c] $ by simp)
         match yb.1 with
         | .nil =>
           eerr.2 (.trivial s.offset (.some ErrorItem.eof) want) s
@@ -377,7 +377,7 @@ instance statetInstance
   getParserState := liftM $ mₚ.getParserState
   updateParserState φ := liftM $ mₚ.updateParserState φ
 
-def withRange (α : Type u) (p : ParsecT m β ℘ E (Range → γ)) [i : MonadParsec (ParsecT m β ℘ E) ℘ α E β] : ParsecT m β ℘ E γ := do
+def withRange (α : Type u) (p : ParsecT m β ℘ E (Range → γ)) [_i : MonadParsec (ParsecT m β ℘ E) ℘ α E β] : ParsecT m β ℘ E γ := do
   let s₀ : State β ℘ E ← MonadParsec.getParserState α
   let first := s₀.posState.sourcePos
   let go ← p
@@ -397,7 +397,7 @@ def parseError {m: Type u → Type v} {℘ α E β: Type u} [MonadParsec m ℘ �
   : Megaparsec.Errors.ParseError.ParseError β E → m γ :=
   MonadParsec.MonadParsec.parseError ℘ α
 
-def label {m: Type u → Type v} {℘ α E β: Type u} [i : MonadParsec.MonadParsec m ℘ α E β] {γ : Type u}
+def label {m: Type u → Type v} {℘ α E β: Type u} [_i : MonadParsec.MonadParsec m ℘ α E β] {γ : Type u}
   : String → m γ → m γ :=
   MonadParsec.MonadParsec.label ℘ α E β
 
@@ -405,7 +405,7 @@ def hidden {m: Type u → Type v} {℘ α E β: Type u} [MonadParsec.MonadParsec
   : m γ → m γ :=
   MonadParsec.MonadParsec.hidden ℘ α E β
 
-def attempt {m: Type u → Type v} {℘ α E β: Type u} [i : MonadParsec.MonadParsec m ℘ α E β] {γ : Type u}
+def attempt {m: Type u → Type v} {℘ α E β: Type u} [_i : MonadParsec.MonadParsec m ℘ α E β] {γ : Type u}
   : m γ → m γ :=
   MonadParsec.MonadParsec.attempt ℘ α E β
 
@@ -425,7 +425,7 @@ def observing {m: Type u → Type v} {℘ α E β: Type u} [MonadParsec.MonadPar
   : m γ → m (Except (Megaparsec.Errors.ParseError.ParseError β E) γ) :=
   MonadParsec.MonadParsec.observing ℘ α
 
-def eof {m: Type u → Type v} {℘ α E β: Type u} [i : MonadParsec.MonadParsec m ℘ α E β] : m PUnit :=
+def eof {m: Type u → Type v} {℘ α E β: Type u} [_i : MonadParsec.MonadParsec m ℘ α E β] : m PUnit :=
   MonadParsec.MonadParsec.eof ℘ α E β
 
 def token {m: Type u → Type v} {℘ α E β: Type u} [MonadParsec.MonadParsec m ℘ α E β]

--- a/Megaparsec/Printable.lean
+++ b/Megaparsec/Printable.lean
@@ -63,14 +63,15 @@ private def charPretty : Char → String
   | ' ' => "space"
   | ch  => (charPretty' ch).getD $ s!"'{ch}'"
 
-private def stringPretty : NEList Char → String
-  | ⟦x⟧ => charPretty x
-  | ⟦'\r','\n'⟧ => "crlf newline"
+private def stringPretty (xs : NEList Char) : String :=
+  match xs.data with
+  | [x] => charPretty x
+  | ['\r','\n'] => "crlf newline"
   | xs =>
     let f c := match charPretty' c with
       | .none => s!"{c}"
       | .some pretty => s!"<{pretty}>"
-    s!"\"{String.join $ f <$> xs.toList}\""
+    s!"\"{String.join $ f <$> xs}\""
 
 --===========================================================--
 --=================== PRINTABLE INSTANCES ===================--
@@ -99,8 +100,5 @@ instance : Printable UInt8 where
 open ByteArray in
 instance : Printable Bit where
   showTokens
-    | ⟦b⟧ => s!"'{b}'"
-    | nl => let rec go b xs := match xs with
-      | [] => [toString b]
-      | y :: ys => toString b :: go y ys
-      s!"\"{String.join $ go nl.head nl.tail}\""
+    | ⟨ [b], _ ⟩ => s!"'{b}'"
+    | ⟨ bs,  _ ⟩ => s!"\"{String.join $ bs.map ToString.toString}\""

--- a/Tests/Parsec.lean
+++ b/Tests/Parsec.lean
@@ -32,7 +32,7 @@ def duplicateErrorsTest : TestSeq :=
       (parse (p <|> p <|> p') "Yatima")
       fun errors =>
         let es := match errors.errors with
-          | ⟦.trivial _ _ exs⟧ => exs.toList
+          | ⟨ [.trivial _ _ exs], _ ⟩ => exs.toList
           | _ => [] -- impossible case for further testing
         let shouldBe := [
           ErrorItem.tokens (List.toNEList 'y' "atima".data),

--- a/Tests/StateT.lean
+++ b/Tests/StateT.lean
@@ -18,14 +18,14 @@ def stateTest : TestSeq :=
 
   let ptSO : StateT Nat (Parsec Char String Unit) String := do
     let x0 ← MonadStateOf.get
-    let fail ← string (i := statetInstance) "fail me"
+    let fail ← string (_i := statetInstance) "fail me"
     MonadStateOf.set $ x0 + 41
     pure fail
 
   let ptST : StateT Nat (Parsec Char String Unit) String := do
     MonadStateOf.set $ 1
     let x0 ← StateT.get
-    let parsed ← string (i := statetInstance) "fail me" <|> pure ""
+    let parsed ← string (_i := statetInstance) "fail me" <|> pure ""
     MonadStateOf.set $ x0 + 41
     pure parsed
 

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -4,9 +4,9 @@
  [{"git":
    {"url": "https://github.com/yatima-inc/YatimaStdLib.lean",
     "subDir?": null,
-    "rev": "b3084d5fb020975555dabe507e6a4db659b0733d",
+    "rev": "49ee890897dbdd4665d0e8c75cd3401f0b4e6f21",
     "name": "YatimaStdLib",
-    "inputRev?": "b3084d5fb020975555dabe507e6a4db659b0733d"}},
+    "inputRev?": "49ee890897dbdd4665d0e8c75cd3401f0b4e6f21"}},
   {"git":
    {"url": "https://github.com/yatima-inc/straume",
     "subDir?": null,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -10,7 +10,7 @@ require LSpec from git
   "https://github.com/yatima-inc/LSpec" @ "88f7d23e56a061d32c7173cea5befa4b2c248b41"
 
 require YatimaStdLib from git
-  "https://github.com/yatima-inc/YatimaStdLib.lean" @ "b3084d5fb020975555dabe507e6a4db659b0733d"
+  "https://github.com/yatima-inc/YatimaStdLib.lean" @ "49ee890897dbdd4665d0e8c75cd3401f0b4e6f21"
 
 require Straume from git
   "https://github.com/yatima-inc/straume" @ "9597873f0b18a9e97b7315fb84968c55d09a6112"


### PR DESCRIPTION
Solution:

  - Incorporate breaking changes. The strategy: - For each double-square bracket match, replace it with anonymous destructor (triangular brackets). - Match the `ne` proof as `_`. - No matches of the empty lists will be needed because Lean incorporates the `ne` proof into case analysis of `match`.
  - While at it, fix unused variables warnings for named instances (call those _i).
  - Update manual instance resolution to use the underscored instance variables.