### PR TITLE
Fix for new definition of NEList

### DIFF
--- a/Megaparsec/Common.lean
+++ b/Megaparsec/Common.lean
@@ -26,7 +26,7 @@ universe u
 section
 
 def single {m : Type u → Type v} {℘ α E β : Type u} [i : MonadParsec m ℘ α E β] [BEq β] (x : β) : m β :=
-  MonadParsec.token ℘ α E (fun y => if x == y then .some x else .none) [ErrorItem.tokens $ NEList.mk [x] $ by simp]
+  MonadParsec.token ℘ α E (fun y => if x == y then .some x else .none) [ErrorItem.tokens [x]]
 
 -- TODO: case-insensitive version
 def string {m : Type u → Type v} {℘ α E β : Type u} [_i : MonadParsec m ℘ α E β] [BEq α] (x : α) : m α :=

--- a/Megaparsec/Errors.lean
+++ b/Megaparsec/Errors.lean
@@ -46,8 +46,8 @@ instance [ToString β] : ToString (ErrorItem β) where
   | .eof => "end of input"
   | .label t => String.mk t.toList
   | .tokens t => match t with
-    | ⟨ [x], _ ⟩ => s!"{x}"
-    | ⟨ x :: xs, _ ⟩ => "\"" ++
+    | ⟨ x, [] ⟩ => s!"{x}"
+    | ⟨ x, xs ⟩ => "\"" ++
       xs.foldl (fun acc token => s!"{acc}{token}") (toString x) ++ "\""
 
 

--- a/Megaparsec/Errors/ParseError.lean
+++ b/Megaparsec/Errors/ParseError.lean
@@ -66,8 +66,8 @@ def NEList.spanToLast (ne : NEList α) : (List α × α) :=
 -- Print a pretty list where items are separated with commas and the word
 -- “or” according to the rules of English punctuation.
 def orList : NEList String → String
-  | ⟨ [x], _ ⟩ => x
-  | ⟨ [x,y], _ ⟩ => s!"{x} or {y}"
+  | ⟨ x, [] ⟩ => x
+  | ⟨ x, [y] ⟩ => s!"{x} or {y}"
   | xs => let (lxs, last) := NEList.spanToLast xs
     String.intercalate ", " lxs ++ ", or " ++ last
 

--- a/Megaparsec/Printable.lean
+++ b/Megaparsec/Printable.lean
@@ -64,7 +64,7 @@ private def charPretty : Char → String
   | ch  => (charPretty' ch).getD $ s!"'{ch}'"
 
 private def stringPretty (xs : NEList Char) : String :=
-  match xs.data with
+  match xs.toList with
   | [x] => charPretty x
   | ['\r','\n'] => "crlf newline"
   | xs =>
@@ -100,5 +100,5 @@ instance : Printable UInt8 where
 open ByteArray in
 instance : Printable Bit where
   showTokens
-    | ⟨ [b], _ ⟩ => s!"'{b}'"
-    | ⟨ bs,  _ ⟩ => s!"\"{String.join $ bs.map ToString.toString}\""
+    | ⟨ b, [] ⟩ => s!"'{b}'"
+    | ⟨ b, bs ⟩ => s!"\"{String.join $ (b::bs).map ToString.toString}\""

--- a/Tests/Parsec.lean
+++ b/Tests/Parsec.lean
@@ -32,7 +32,7 @@ def duplicateErrorsTest : TestSeq :=
       (parse (p <|> p <|> p') "Yatima")
       fun errors =>
         let es := match errors.errors with
-          | ⟨ [.trivial _ _ exs], _ ⟩ => exs.toList
+          | ⟨ .trivial _ _ exs, [] ⟩ => exs.toList
           | _ => [] -- impossible case for further testing
         let shouldBe := [
           ErrorItem.tokens (List.toNEList 'y' "atima".data),

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -4,9 +4,9 @@
  [{"git":
    {"url": "https://github.com/yatima-inc/YatimaStdLib.lean",
     "subDir?": null,
-    "rev": "533d71efa5853ff014f42c174d6321d74251209f",
+    "rev": "7af015ddd688052cd14f7dedea6856b943ed25ed",
     "name": "YatimaStdLib",
-    "inputRev?": "533d71efa5853ff014f42c174d6321d74251209f"}},
+    "inputRev?": "7af015ddd688052cd14f7dedea6856b943ed25ed"}},
   {"git":
    {"url": "https://github.com/yatima-inc/straume",
     "subDir?": null,


### PR DESCRIPTION
Apart from a few `match` changes, it actually simplified the code by removing all redundant `NEList.mk` using the `simp` tactic